### PR TITLE
Возвращены старые уровни сложности для экспедиций

### DIFF
--- a/Content.Client/Salvage/UI/SalvageExpeditionConsoleBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageExpeditionConsoleBoundUserInterface.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Client.Stylesheets;
 using Content.Shared.CCVar;
 using Content.Shared.Procedural;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Salvage.Expeditions;
 using Content.Shared.Salvage.Expeditions.Modifiers;
 using JetBrains.Annotations;
@@ -9,6 +10,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 
 namespace Content.Client.Salvage.UI;
 
@@ -64,8 +66,11 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
             var offering = new OfferingWindowOption();
             offering.Title = Loc.GetString($"salvage-expedition-type");
 
-            var difficultyId = "Moderate";
-            var difficultyProto = _protoManager.Index<SalvageDifficultyPrototype>(difficultyId);
+            //WL-Changes-start
+            //var difficultyId = "Moderate";
+            var difficultyProto = _protoManager.Index<SalvageDifficultyPrototype>(missionParams.Difficulty);
+            //WL-Changes-end
+
             // TODO: Selectable difficulty soon.
             var mission = salvage.GetMission(difficultyProto, missionParams.Seed);
 
@@ -80,7 +85,7 @@ public sealed class SalvageExpeditionConsoleBoundUserInterface : BoundUserInterf
 
             offering.AddContent(new Label
             {
-                Text = Loc.GetString("salvage-expedition-difficulty-Moderate"),
+                /*WL-Changes*/Text = Loc.GetString($"salvage-expedition-difficulty-{difficultyProto.ID}"),
                 FontColorOverride = difficultyColor,
                 HorizontalAlignment = Control.HAlignment.Left,
                 Margin = new Thickness(0f, 0f, 0f, 5f),

--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -4,6 +4,7 @@ using Content.Server.Salvage.Expeditions;
 using Content.Server.Salvage.Expeditions.Structure;
 using Content.Shared.CCVar;
 using Content.Shared.Examine;
+using Content.Shared.Procedural;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Salvage.Expeditions;
 using Robust.Shared.Audio;
@@ -11,6 +12,7 @@ using Robust.Shared.CPUJob.JobQueues;
 using Robust.Shared.CPUJob.JobQueues.Queues;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
+using Robust.Shared.Random;
 
 namespace Content.Server.Salvage;
 
@@ -139,13 +141,17 @@ public sealed partial class SalvageSystem
     {
         component.Missions.Clear();
 
+        //WL-Changes-start
+        var difficulties = _prototypeManager.EnumeratePrototypes<SalvageDifficultyPrototype>();
+        //WL-Changes-end
+
         for (var i = 0; i < MissionLimit; i++)
         {
             var mission = new SalvageMissionParams
             {
                 Index = component.NextIndex,
                 Seed = _random.Next(),
-                Difficulty = "Moderate",
+                /*WL-Changes*/Difficulty = _random.Pick((IReadOnlyList<SalvageDifficultyPrototype>) difficulties).ID,
             };
 
             component.Missions[component.NextIndex++] = mission;

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -117,7 +117,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
 
         // Setup mission configs
         // As we go through the config the rating will deplete so we'll go for most important to least important.
-        var difficultyId = "Moderate";
+        /*WL-Changes*/ var difficultyId = _missionParams.Difficulty/*"Moderate"*/;
         var difficultyProto = _prototypeManager.Index<SalvageDifficultyPrototype>(difficultyId);
 
         var mission = _entManager.System<SharedSalvageSystem>()

--- a/Resources/Prototypes/_WL/Procedural/salvage_difficulties.yml
+++ b/Resources/Prototypes/_WL/Procedural/salvage_difficulties.yml
@@ -1,0 +1,15 @@
+- type: salvageDifficulty
+  id: Hazardous
+  lootBudget: 55
+  mobBudget: 70
+  modifierBudget: 3
+  color: "#7d1379"
+  recommendedPlayers: 3
+
+- type: salvageDifficulty
+  id: Extreme
+  lootBudget: 90
+  mobBudget: 120
+  modifierBudget: 4
+  color: "#7d1313"
+  recommendedPlayers: 4


### PR DESCRIPTION
## Описание PR
Возвращены старые уровни сложности экспедиций: сложная, экстремальная. Количество модификаторов, лута, мобов настроено в связи с названиями сложностей.
Утилизаторы довольно популярная роль, поэтому имеют место быть дополнительные сложности для 3-4 человек.

**Медиа**
![Скриншот 20-07-2024 183152](https://github.com/user-attachments/assets/0f439f01-ba3f-4214-bf34-2aba119d81a3)
![Скриншот 20-07-2024 183228](https://github.com/user-attachments/assets/c288c1d8-b057-4e5c-8035-e2d8b791ba5c)


**Проверки**
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

:cl:
- tweak: Возвращены старые уровни для экспедиций
