### PR TITLE
Fixed paradox clone ooc text (flavor)

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -190,12 +190,13 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             _metaSystem.SetEntityName(entity.Value, profile.Name);
 
             ////WL-changes-start
-            //if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText)) 
+            //if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
             //{
             //    AddComp<DetailExaminableComponent>(entity.Value).Content = profile.FlavorText;
             //}
 
             EnsureComp<CharacterInformationComponent>(entity.Value).FlavorText = profile.FlavorText; // WL-CharacterInformation
+            EnsureComp<CharacterInformationComponent>(entity.Value).OocText = profile.OocText;
             ////WL-changes-end
         }
 

--- a/Content.Server/_WL/CharacterInformation/CharacterInformationComponent.cs
+++ b/Content.Server/_WL/CharacterInformation/CharacterInformationComponent.cs
@@ -9,4 +9,8 @@ public sealed partial class CharacterInformationComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("flavorText")]
     public string FlavorText = string.Empty;
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("oocText")]
+    public string OocText = string.Empty;
 }

--- a/Content.Server/_WL/CharacterInformation/CharacterInformationSystem.cs
+++ b/Content.Server/_WL/CharacterInformation/CharacterInformationSystem.cs
@@ -54,12 +54,8 @@ public sealed class CharacterInformationSystem : EntitySystem
         if (!TryComp<CharacterInformationComponent>(targetUid, out var charInfo))
             return;
 
-        HumanoidCharacterProfile? profile = null;
-        if (TryComp<ActorComponent>(targetUid, out var actor)) // Enrich with private info if player control mob
-            profile = (HumanoidCharacterProfile) _preferencesManager.GetPreferences(actor.PlayerSession.UserId).SelectedCharacter;
-
         var charName = Identity.Name(targetUid, EntityManager);
-        var state = new CharacterInformationBuiState(GetNetEntity(targetUid), charName, charInfo.FlavorText, profile?.OocText);
+        var state = new CharacterInformationBuiState(GetNetEntity(targetUid), charName, charInfo.FlavorText, charInfo.OocText);
         _userInterfaceSystem.SetUiState(uid, CharacterInformationUiKey.Key, state);
     }
 }


### PR DESCRIPTION
## Описание PR
Исправлено отображение OOC-заметок у парадоксального клона: теперь там показываются OOC-заметки персонажа-жертвы, а не персонажа игрока, который попал на рольку клона.

Часть таска: [[Bug] Траблы парадоксального клона on Прототиперы | Trello](https://trello.com/c/eq1n4qOK/41-bug-%D1%82%D1%80%D0%B0%D0%B1%D0%BB%D1%8B-%D0%BF%D0%B0%D1%80%D0%B0%D0%B4%D0%BE%D0%BA%D1%81%D0%B0%D0%BB%D1%8C%D0%BD%D0%BE%D0%B3%D0%BE-%D0%BA%D0%BB%D0%BE%D0%BD%D0%B0)

## Технические детали
В компонент CharacterInfo добавлено поле OocText, чтобы передавать его в CharacterInformationWindow. До этого извлекалось из профиля игрока зачем-то (*кринж, бро*).

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md), [NDA](../NDA.md), и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl:
- wl-fix: исправлены OOC-заметки парадоксальных клонов
