### PR TITLE
Reduced return to lobby cooldown to 10 minutes

### DIFF
--- a/Content.Shared/_WL/CCVars/WLCCVars.cs
+++ b/Content.Shared/_WL/CCVars/WLCCVars.cs
@@ -15,7 +15,7 @@ public sealed class WLCVars
     /// Через сколько времени(в секундах) появится кнопка возвращения в лобби.
     /// </summary>
     public static readonly CVarDef<int> GhostReturnToLobbyButtonCooldown =
-        CVarDef.Create("ghost.return_to_lobby_button_cooldown", 10*60, CVar.SERVERONLY);
+        CVarDef.Create("ghost.return_to_lobby_button_cooldown", 600, CVar.SERVERONLY); //WL-changes  (10 minutes)
 
     /// <summary>
     /// Нужно ли проверять игрока на возраст при выборе роли.

--- a/Content.Shared/_WL/CCVars/WLCCVars.cs
+++ b/Content.Shared/_WL/CCVars/WLCCVars.cs
@@ -15,7 +15,7 @@ public sealed class WLCVars
     /// Через сколько времени(в секундах) появится кнопка возвращения в лобби.
     /// </summary>
     public static readonly CVarDef<int> GhostReturnToLobbyButtonCooldown =
-        CVarDef.Create("ghost.return_to_lobby_button_cooldown", 1200, CVar.SERVERONLY);
+        CVarDef.Create("ghost.return_to_lobby_button_cooldown", 10*60, CVar.SERVERONLY);
 
     /// <summary>
     /// Нужно ли проверять игрока на возраст при выборе роли.


### PR DESCRIPTION
## Описание PR
Уменьшено время возвращение в лобби до 10 минут (было 20).

## Почему / Баланс
Таск: [Возращение в лобби on Прототиперы | Trello](https://trello.com/c/FysLWksg/34-%D0%B2%D0%BE%D0%B7%D1%80%D0%B0%D1%89%D0%B5%D0%BD%D0%B8%D0%B5-%D0%B2-%D0%BB%D0%BE%D0%B1%D0%B1%D0%B8)

## Технические детали
Изменено время по умолчанию, а не в конфиге.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: время возвращения в лобби уменьшено до 10 минут
