### PR TITLE
Changed some job age requirements

### DIFF
--- a/Resources/Prototypes/Corvax/Roles/Jobs/Command/iaa.yml
+++ b/Resources/Prototypes/Corvax/Roles/Jobs/Command/iaa.yml
@@ -11,7 +11,7 @@
     department: Security
     time: 36000
   - !type:AgeRequirement
-    minAge: 30
+    minAge: 27 # WL-Changes-AgeRequirement
   startingGear: IAAGear
   icon: "JobIconIAA"
   supervisors: job-supervisors-centcom

--- a/Resources/Prototypes/Corvax/Roles/Jobs/Security/pilot.yml
+++ b/Resources/Prototypes/Corvax/Roles/Jobs/Security/pilot.yml
@@ -10,7 +10,7 @@
     department: Security
     time: 72000 #20 hrs
   - !type:AgeRequirement
-    minAge: 23
+    minAge: 22 # WL-Changes-AgeRequirement
   startingGear: PilotGear
   icon: "JobIconPilot"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -18,7 +18,7 @@
 #    - !type:OverallPlaytimeRequirement
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
-      minAge: 28
+      minAge: 24 # WL-Changes-AgeRequirement
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -23,6 +23,11 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
+  # WL-Changes-AgeRequirement Start
+  requirements:
+    - !type:AgeRequirement
+      minAge: 22
+  # WL-Changes-AgeRequirement End
 
 - type: startingGear
   id: ChaplainGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -19,7 +19,7 @@
     - !type:OverallPlaytimeRequirement
       time: 504000 #140 hrs # Corvax-RoleTime
     - !type:AgeRequirement
-      minAge: 35
+      minAge: 30 # WL-Changes-AgeRequirement
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -21,7 +21,7 @@
     - !type:OverallPlaytimeRequirement
       time: 180000 #50 hrs # Corvax-RoleTime
     - !type:AgeRequirement
-      minAge: 30
+      minAge: 26 # WL-Changes-AgeRequirement
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -8,7 +8,7 @@
       department: Engineering
       time: 36000 #10 hrs # Corvax-RoleTime
     - !type:AgeRequirement
-      minAge: 25
+      minAge: 22 # WL-Changes-AgeRequirement
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -13,7 +13,7 @@
       department: Engineering
       time: 18000 #5 hrs # Corvax-RoleTime
     - !type:AgeRequirement
-      minAge: 25
+      minAge: 22 # WL-Changes-AgeRequirement
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -18,7 +18,7 @@
 #    - !type:OverallPlaytimeRequirement
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
-      minAge: 35
+      minAge: 30 # WL-Changes-AgeRequirement
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -13,7 +13,7 @@
       department: Medical
       time: 7200 #2 hrs # Corvax-RoleTime
     - !type:AgeRequirement
-      minAge: 26
+      minAge: 24 # WL-Changes-AgeRequirement
   startingGear: DoctorGear
   icon: "JobIconMedicalDoctor"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -13,6 +13,8 @@
       department: Medical
       time: 36000 #10 hrs # Corvax-RoleTime
       inverted: true # stop playing intern if you're good at med!
+    - !type:AgeRequirement # WL-Changes-AgeRequirement
+      minAge: 20
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -10,7 +10,7 @@
     - !type:OverallPlaytimeRequirement
       time: 54000 # 15 hrs
     - !type:AgeRequirement
-      minAge: 20
+      minAge: 22 # WL-Changes-AgeRequirement
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -12,6 +12,8 @@
       department: Science
       time: 36000 #10 hrs # Corvax-RoleTime
       inverted: true # stop playing intern if you're good at science!
+    - !type:AgeRequirement # WL-Changes-AgeRequirement
+      minAge: 20
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -12,7 +12,7 @@
 #    - !type:OverallPlaytimeRequirement
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
-      minAge: 35
+      minAge: 30 # WL-Changes-AgeRequirement
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -14,7 +14,7 @@
       department: Science
       time: 18000 #5 hrs # Corvax-RoleTime
     - !type:AgeRequirement
-      minAge: 25
+      minAge: 24 # WL-Changes-AgeRequirement
   startingGear: ScientistGear
   icon: "JobIconScientist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -16,7 +16,7 @@
 #    - !type:OverallPlaytimeRequirement
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
-      minAge: 30
+      minAge: 27 # WL-Changes-AgeRequirement
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobPsychologist
   requirements:
     - !type:AgeRequirement
-      minAge: 27
+      minAge: 22 # WL-Changes-AgeRequirement
   subnames:
   - Male: психиатр
   - Male: психотерапевт


### PR DESCRIPTION
## Описание PR
Сменены требование к возрасту по ролям согласно с [Обсуждение:Возраста и должности (WhiteList) — Space Station 14 Вики](https://station14.ru/wiki/%D0%9E%D0%B1%D1%81%D1%83%D0%B6%D0%B4%D0%B5%D0%BD%D0%B8%D0%B5:%D0%92%D0%BE%D0%B7%D1%80%D0%B0%D1%81%D1%82%D0%B0_%D0%B8_%D0%B4%D0%BE%D0%BB%D0%B6%D0%BD%D0%BE%D1%81%D1%82%D0%B8_(WhiteList)) на момент 07.05.2025.

## Почему / Баланс
Так сказала Варта. Ничего не знаю.

## Технические детали
Прошёлся, поменял, кое-где добавил ограничение по роли на возраст.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
:cl:
- wl-tweak: Изменены в меньшую сторону ограничения ролей на возраст