### PR TITLE
Пофикшен баг в менюшке оос описания если спрайт слишком широкий

### DIFF
--- a/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml
+++ b/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml
@@ -1,11 +1,12 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
+<controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:style="clr-namespace:Content.Client.Stylesheets"
-                      Title="{Loc 'character-information-ui-title'}" Name="RootWindow" MinSize="700 350" Resizable="True">
+                      Title="{Loc 'character-information-ui-title'}" Name="RootWindow" MinSize="700 350" Resizable="True"
+                      HorizontalExpand="True">
     <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" HorizontalExpand="True" VerticalExpand="True" Margin="8">
-        <BoxContainer Orientation="Vertical" VerticalAlignment="Center">
+        <BoxContainer Orientation="Vertical" VerticalAlignment="Center" HorizontalExpand="True">
             <SpriteView Name="CharSprite" Scale="8 8" VerticalAlignment="Center" />
             <RichTextLabel Name="Name" Margin="0 5 0 0" HorizontalAlignment="Center" />
         </BoxContainer>
@@ -18,9 +19,9 @@
 
         <ScrollContainer Name="TextScroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True" MinWidth="400">
 			<BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
-				<Label Name="FlavorTextLabel" Visible="False" Text="{Loc 'character-information-ui-flavor-text'}" />
+				<Label Name="FlavorTextLabel" HorizontalExpand="True" Visible="False" Text="{Loc 'character-information-ui-flavor-text'}" />
                 <RichTextLabel Name="FlavorText" HorizontalExpand="True" />
-				<Label Name="OocTextLabel" Visible="False" Text="{Loc 'character-information-ui-ooc-text'}" Margin="0 10 0 0" />
+				<Label Name="OocTextLabel" HorizontalExpand="True" Visible="False" Text="{Loc 'character-information-ui-ooc-text'}" Margin="0 10 0 0" />
 				<RichTextLabel Name="OocText" HorizontalExpand="True" />
             </BoxContainer>
         </ScrollContainer>

--- a/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml.cs
+++ b/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Content.Client.Message;
 using Content.Client.UserInterface.Controls;
 using Content.Shared._WL.CharacterInformation;
@@ -50,14 +50,12 @@ public sealed partial class CharacterInformationWindow : FancyWindow
             Separator.Visible = false;
             TextScroll.Visible = false;
             RootWindow.MinSize = new Vector2(280, 400);
-            RootWindow.SetSize = new Vector2(280, 400);
         }
         else
         {
             Separator.Visible = true;
             TextScroll.Visible = true;
             RootWindow.MinSize = new Vector2(700, 400);
-            RootWindow.SetSize = new Vector2(700, 400);
         }
     }
 }


### PR DESCRIPTION
## Описание PR
Фикс по таску с трелло

## Медиа
Было:
https://discord.com/channels/1066727245806325872/1363221037365596190/1363221037365596190
Стало:
![ААА](https://github.com/user-attachments/assets/c4249466-ac39-4afe-bd8a-b17319b8b4cf)

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

:cl:
- wl-fix: Исправлен баг с корявым отображением меню ООС описания при широком спрайте персонажа
