### PR TITLE
Fixed maints renga spawners size

### DIFF
--- a/Resources/Prototypes/_WL/Procedural/Themes/maints_wlrenga.yml
+++ b/Resources/Prototypes/_WL/Procedural/Themes/maints_wlrenga.yml
@@ -31,12 +31,14 @@
   - MaintsRenga
 
 - type: entity
-  id: MaintsDepartmentalRengaRoomMarker
   parent: BaseRoomMarker
+  id: MaintsDepartmentalRengaRoomMarker
   name: Maints interior marker
   suffix: 15x15, Renga
   components:
   - type: RoomFill
+    minSize: 15,15
+    maxSize: 15,15
     roomWhitelist:
       tags:
       - MaintsRenga


### PR DESCRIPTION
Исправлен размер процедурных техов ренги. Теперь они могут спавнится. Проблема была в том, что по умолчанию эти поля заполнены как `minSize: 3,3` и `maxSize: 10,10`, поэтому техи ренги отбрасывались как неподходящие. Fixes #153.

Проверка подходящих размеров при спавне комнаты:
https://github.com/corvax-team/ss14-wl/blob/17850e6baa46bd00c21b4b2b26d44ef6ae57f217/Content.Server/Procedural/DungeonSystem.Rooms.cs#L43-L49

Поля по умолчанию:
https://github.com/corvax-team/ss14-wl/blob/17850e6baa46bd00c21b4b2b26d44ef6ae57f217/Content.Server/Procedural/RoomFillComponent.cs#L18-L28