### PR TITLE
360 круглосуточный обзор

### DIFF
--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -48,5 +48,18 @@ namespace Content.Shared.CombatMode
         /// </summary>
         [DataField, AutoNetworkedField]
         public bool ToggleMouseRotator = true;
+        // Corvax-WL-NoScope-Start
+        /// <summary>
+        ///     If true, sets <see cref="MouseRotatorComponent.AngleTolerance"/> to 1 degree and <see cref="MouseRotatorComponent.Simple4DirMode"/>
+        ///     to false when the owner enters combatmode. This is currently being tested as of 06.12.24,
+        ///     so a simple bool switch should suffice.
+        ///     Leaving AutoNetworking just in case shitmins need to disable it for someone. Will only take effect when re-enabling combat mode.
+        /// </summary>
+        /// <remarks>
+        ///     No effect if <see cref="ToggleMouseRotator"/> is false.
+        /// </remarks>
+        [DataField, AutoNetworkedField]
+        public bool SmoothRotation = true;
+        // Corvax-WL-NoScope-End
     }
 }

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -87,7 +87,14 @@ public abstract class SharedCombatModeSystem : EntitySystem
     {
         if (value)
         {
-            EnsureComp<MouseRotatorComponent>(uid);
+            // Corvax-WL-NoScope-Start
+            var rot = EnsureComp<MouseRotatorComponent>(uid);
+            if (TryComp<CombatModeComponent>(uid, out var comp) && comp.SmoothRotation) // no idea under which (intended) circumstances this can fail (if any), so i'll avoid Comp<>().
+            {
+                rot.AngleTolerance = Angle.FromDegrees(1); // arbitrary
+                rot.Simple4DirMode = false;
+            }
+            // Corvax-WL-NoScope-End
             EnsureComp<NoRotateOnMoveComponent>(uid);
         }
         else


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
 Теперь с харм мода мы поворачиваемся плавно за курсором, а не на 4 стороны.

## Почему / Баланс
 Удобство использования фонариков, красоты кручения на стуле.

## Медиа

https://github.com/user-attachments/assets/b99b5896-2246-4dc8-924f-522bb570b165

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: Теперь, в харм моде, фонарики могут поворачиваться на все 360 градусов.
