### PR TITLE
Кошачьи черты внешности

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -3,7 +3,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [Human]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   coloring:
     default:
       type:
@@ -27,7 +27,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [Human]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   coloring:
     default:
       type:
@@ -51,7 +51,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [Human]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   coloring:
     default:
       type:
@@ -75,7 +75,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [Human]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/slime_cat_parts.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/slime_cat_parts.yml
@@ -3,7 +3,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_cat_outer
@@ -15,7 +15,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: slime_tail_cat_wag # Corvax-Sponsors
@@ -25,7 +25,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_stubby_outer
@@ -37,7 +37,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_curled_outer
@@ -49,7 +49,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_torn_outer
@@ -61,7 +61,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   sprites:
     - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
       state: slime_tail_cat_wag_stripes_prime

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -3,7 +3,7 @@
   bodyPart: Special
   markingCategory: Special
   speciesRestriction: [Human]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   coloring:
     default:
       type:
@@ -27,7 +27,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [Human]
-  sponsorOnly: true # Corvax-Sponsors
+  #sponsorOnly: true # Corvax-Sponsors
   coloring:
     default:
       type:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Закомментировал SponsorOnly у кошачьих частей, проверил на локалке, сработало.

## Почему / Баланс
  У вульп также сделали, но, даже если у тебя куплен донат, ты не можешь носить ушки.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-fix: Теперь все могут носить кошачьи черты внешности.
