### PR TITLE
Увеличенна добыча газодобытчика кислорода

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -64,6 +64,7 @@
   components:
     - type: GasMiner
       maxExternalPressure: 4500
+      spawnAmount: 700
 
 - type: entity
   name: N2 gas miner
@@ -91,6 +92,7 @@
   components:
     - type: GasMiner
       maxExternalPressure: 4500
+      spawnAmount: 500
 
 - type: entity
   name: CO2 gas miner

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -92,7 +92,6 @@
   components:
     - type: GasMiner
       maxExternalPressure: 4500
-      spawnAmount: 500
 
 - type: entity
   name: CO2 gas miner

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -64,7 +64,7 @@
   components:
     - type: GasMiner
       maxExternalPressure: 4500
-      spawnAmount: 700
+      spawnAmount: 700 # WL-Changes
 
 - type: entity
   name: N2 gas miner


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Почему / Баланс
  Кислород нужен везде: в сжигателе, в тритии и фрезоне, но его, в продуктивных схемах, может не хватать.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

:cl:
- wl-tweak: Изменено кол-во производимых молей станционного газодобытчика (4.5 МПа) кислорода от 400 до 700.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance**
  * Large Station Oxygen Gas Miner spawn amount increased to 700 for faster oxygen generation and improved supply stability.
  * Change affects only the Large O2 miner; all other gas miners unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->