### PR TITLE
Обновление цепи разряда СМЭСов

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -126,6 +126,7 @@
     startingCharge: 8000000
   - type: PowerNetworkBattery # WL-Changes
     supplyRampTolerance: 10000
+    supplyRampRate: 1250
 
 - type: entity
   parent: SMESBasic
@@ -173,6 +174,7 @@
     state: advancedsmes-static
   - type: PowerNetworkBattery # WL-Changes
     supplyRampTolerance: 17250
+    supplyRampRate: 1500
 
 - type: entity
   parent: SMESAdvanced


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Почему / Баланс
 Во вкладке "Медиа". Кратко текстом: позволяет предотвращать мигание ламп при отключении питания. Важно: не исправляет рампу ЛКП, и потому при подключении, скажем, адского охладителя, свет всё равно моргнёт (Поставьте больше ЛКП).


  Напрягу мапперов и себя сделать на картах крутую схему питания, чтоб не моргало. Без увеличения толеранций этого можно добиться только если натыкать больше СМЭСов.


  Странно, что СМЭС, объёмом больше чем подстанция, имеет точно такую же толеранцию, не говоря уж об продвинутом.

## Медиа

https://github.com/user-attachments/assets/e30bb30d-8355-49d7-85cf-b46d564304c1

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

:cl:
- wl-tweak: Изменён мгновенный выход СМЭСа (10 квт) и продвинутого СМЭСа (17.25 квт) при разряде цепи.
- wl-tweak: Изменена рампа повышения разряда цепи (Значения 1250 и 1500 соответственно)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SMES units now include enhanced internal battery behavior for smoother power delivery. Basic SMES handles rapid supply changes more reliably with faster ramp-up, reducing brownouts during load spikes.
  * Advanced SMES gains higher tolerance and an increased ramp rate, improving grid stability under heavy or fluctuating demand and shortening recovery time after surges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->