### PR TITLE
Adding standing require to two-handed guns

### DIFF
--- a/Content.Shared/_WL/CombatStand/CombatStandSystem.cs
+++ b/Content.Shared/_WL/CombatStand/CombatStandSystem.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
+using Content.Shared.Timing;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Standing;
+using Robust.Shared.Collections;
+using Robust.Shared.Timing;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.CombatStand;
+
+public sealed class CombatStandSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GunStandingRequiredComponent, ShotAttemptedEvent>(OnShootAttempt);
+        SubscribeLocalEvent<GunStandingRequiredComponent, ExaminedEvent>(OnExamineRequires);
+    }
+
+    private void OnShootAttempt(EntityUid uid, GunStandingRequiredComponent component, ref ShotAttemptedEvent args)
+    {
+        if (TryComp<StandingStateComponent>(args.User, out var standable) &&
+            !standable.Standing &&
+            TryComp<GunStandingRequiredComponent>(uid, out var standreq)
+            )
+        {
+            args.Cancel();
+
+            var time = _timing.CurTime;
+            if (time > component.LastPopup + component.PopupCooldown)
+            {
+                component.LastPopup = time;
+                var message = Loc.GetString("standing-component-requires", ("item", uid));
+
+                _popup.PopupClient(message, args.Used, args.User);
+            }
+        }
+    }
+
+    private void OnExamineRequires(Entity<GunStandingRequiredComponent> entity, ref ExaminedEvent args)
+    {
+        if (entity.Comp.StandRequiresExamineMessage != null)
+            args.PushText(Loc.GetString(entity.Comp.StandRequiresExamineMessage));
+    }
+
+}
+
+
+[RegisterComponent, NetworkedComponent, Access(typeof(CombatStandSystem)), AutoGenerateComponentState]
+public sealed partial class GunStandingRequiredComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastPopup;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public LocId? StandRequiresExamineMessage  = "gunstandingrequired-component-examine";
+}

--- a/Resources/Locale/en-US/_WL/combatstand/stand-component.ftl
+++ b/Resources/Locale/en-US/_WL/combatstand/stand-component.ftl
@@ -1,0 +1,3 @@
+standing-component-requires = You must stand to shoot { CAPITALIZE(THE($item))}!
+
+gunstandingrequired-component-examine = This weapon can only be fired when you stand.

--- a/Resources/Locale/ru-RU/_WL/combatstand/stand-component.ftl
+++ b/Resources/Locale/ru-RU/_WL/combatstand/stand-component.ftl
@@ -1,0 +1,3 @@
+standing-component-requires = Вы должны стоять, чтобы стрелять из { CAPITALIZE($item)}!
+
+gunstandingrequired-component-examine = Из этого оружия можно стрелять только стоя.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
@@ -11,5 +11,4 @@
   - type: Gun
     minAngle: 21
     maxAngle: 32
-    # WL-Changes: CombatStandSystem (из двуручного оружия нельзя стрелять лёжа)
-  - type: GunStandingRequired
+  - type: GunStandingRequired # WL-Changes: CombatStandSystem (из двуручного оружия нельзя стрелять лёжа) 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
@@ -12,4 +12,4 @@
     minAngle: 21
     maxAngle: 32
     # WL-Changes: CombatStandSystem (из двуручного оружия нельзя стрелять лёжа)
-  - type: GunStandingRequiredComponent
+  - type: GunStandingRequired

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
@@ -10,4 +10,6 @@
     maxAngle: -30
   - type: Gun
     minAngle: 21
-    maxAngle: 32   
+    maxAngle: 32
+    # WL-Changes: CombatStandSystem (из двуручного оружия нельзя стрелять лёжа)
+  - type: GunStandingRequiredComponent


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Теперь из двуручного оружия нельзя стрелять лёжа.

## Почему / Баланс
Предложение игроков, не даёт абузить лежание при стрельбе.

## Технические детали
Добавлена система CombatStandSystem в Content.Shared и соответствующий компонент. Компонент при лежании не даёт стрелять из оружия.

## Медиа
https://github.com/user-attachments/assets/87af78e3-fea8-4605-89f3-115f2536963e

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- wl-tweak: Двуручное огнестрельное оружие теперь нельзя использовать лёжа

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Certain guns now require you to be standing to fire; shots are blocked if you’re not.
  * A localized popup explains when a shot is prevented, with a short cooldown to limit spam.
  * Examining applicable weapons now shows a note about the standing requirement.

* **Localization**
  * New English and Russian messages for the standing requirement and examine text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->