### PR TITLE
Добавлено ползанье под столами

### DIFF
--- a/Content.Client/_WL/Standing/ClientStandingStateSystem.cs
+++ b/Content.Client/_WL/Standing/ClientStandingStateSystem.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Standing;
+using Content.Shared.GameTicking;
+using Robust.Client.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._WL.Standing
+{
+    public sealed partial class ClientStandingStateSystem : EntitySystem
+    {
+        private Dictionary<EntProtoId, Shared.DrawDepth.DrawDepth> _cachedDrawDepths = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<StandingStateComponent, DownedEvent>(OnDowned);
+            SubscribeLocalEvent<StandingStateComponent, StoodEvent>(OnStood);
+
+            SubscribeNetworkEvent<RoundRestartCleanupEvent>(OnRoundEnd);
+
+            _cachedDrawDepths = new();
+        }
+
+        private void OnStood(EntityUid ent, StandingStateComponent comp, ref StoodEvent args)
+        {
+            var user = ent;
+            var prototype = Prototype(user);
+
+            if (prototype == null)
+                return;
+
+            if (!TryComp<SpriteComponent>(user, out var spriteComp))
+                return;
+
+            if (!_cachedDrawDepths.TryGetValue(prototype.ID, out var oldDrawDepth))
+            {
+                oldDrawDepth = Shared.DrawDepth.DrawDepth.Objects;
+            }
+
+            spriteComp.DrawDepth = (int)oldDrawDepth;
+        }
+
+        private void OnDowned(EntityUid ent, StandingStateComponent comp, ref DownedEvent args)
+        {
+            var user = ent;
+            var prototype = Prototype(user);
+
+            if (prototype == null)
+                return;
+
+            if (!TryComp<SpriteComponent>(user, out var spriteComp))
+                return;
+
+            if (!_cachedDrawDepths.TryGetValue(prototype.ID, out var oldDrawDepth))
+            {
+                if (TryComp<SpriteComponent>(user, out var innerSpriteCompNull) &&
+                    innerSpriteCompNull is SpriteComponent innerSpriteComp)
+                {
+                    var dd = (Shared.DrawDepth.DrawDepth)innerSpriteComp.DrawDepth;
+                    _cachedDrawDepths[prototype.ID] = dd;
+                }
+            }
+
+            spriteComp.DrawDepth = (int)Shared.DrawDepth.DrawDepth.WallTops;
+        }
+
+        private void OnRoundEnd(RoundRestartCleanupEvent _)
+        {
+            _cachedDrawDepths.Clear();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Теперь под столами можно ползать.

## Почему / Баланс
Игроки давно просили, а из двурука теперь нельзя стрелять лёжа.

## Технические детали
Добавлена клиентская система, меняющая глубину спрайтов при ползаньи.

## Медиа
<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/198ef579-e6ea-4756-ab87-2763d94608e8" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- wl-add: Добавлена возможность ползать под столами.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Characters now automatically change their visual layering when downed, ensuring they appear appropriately relative to walls and objects, and restore their previous layering when they stand up.
  * Improves scene readability during combat or accidents by making downed states more visually distinct.
  * Visual state is reset correctly between rounds to prevent lingering display inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->