### PR TITLE
Удаление использования mappingclientsidesetup при прописывании mapping

### DIFF
--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -161,7 +161,7 @@ namespace Content.Server.Mapping
                 _mappingSystem.ToggleAutosave(mapId, toLoad ?? "NEWMAP");
 
             shell.ExecuteCommand($"tp 0 0 {mapId}");
-            shell.RemoteExecuteCommand("mappingclientsidesetup");
+         // shell.RemoteExecuteCommand("mappingclientsidesetup"); // Corvax WL Changes
             DebugTools.Assert(_mapSystem.IsPaused(mapId));
 
             if (args.Length != 2)


### PR DESCRIPTION
## Почему / Баланс
 Да надоел шлак весь с левой стороны постоянно

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

:cl:
- wl-tweak: Теперь на клиенте не прописывается команда mappingclientsidesetup, при прописывании mapping