### PR TITLE
Изменения минимального и максимального онлайна карт

### DIFF
--- a/Resources/Prototypes/_WL/Maps/Whitelist/wl_kolter.yml
+++ b/Resources/Prototypes/_WL/Maps/Whitelist/wl_kolter.yml
@@ -5,7 +5,7 @@
   mapPath: /Maps/_WL/wl_kolter.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 15
+  minPlayers: 0
   stations:
     CorvaxKolter:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_WL/Maps/Whitelist/wl_paper.yml
+++ b/Resources/Prototypes/_WL/Maps/Whitelist/wl_paper.yml
@@ -1,11 +1,11 @@
 # Special Map for Corvax - Whitelist
 - type: gameMap
   id: CorvaxWLPaper
-  mapName: 'Пейпер'
+  mapName: 'Папер'
   mapPath: /Maps/_WL/wl_paper.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 15
+  minPlayers: 0
   stations:
     CorvaxPaper:
       stationProto: StandardNanotrasenStation
@@ -14,7 +14,7 @@
           mapNameTemplate: '{0} Пейпер {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: 'MFK'
+            prefixCreator: 'MFO'
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/_WL/Shuttles/emergency_wlpaper.yml
         - type: StationJobs

--- a/Resources/Prototypes/_WL/Maps/Whitelist/wl_prairie.yml
+++ b/Resources/Prototypes/_WL/Maps/Whitelist/wl_prairie.yml
@@ -6,6 +6,7 @@
   maxRandomOffset: 0
   randomRotation: false
   minPlayers: 0
+  maxPlayers: 15
   stations:
     CorvaxPrairie:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Почему / Баланс
Да потому что Прерию предлагает на 30 онлайна, а папер, которая вполне играбильна на 5, как и наностанция, минимум требует 15. Бредик не несём.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).


:cl:
- wl-tweak: Изменён минимальный требуемый онлайн для карт до 0: Колтер, Папер. 
- wl-tweak: Изменён максимальный требуемый онлайн для карт: до 15 человек на Прерии.