### PR TITLE
TTS fix

### DIFF
--- a/Content.Server/Corvax/TTS/TTSSystem.cs
+++ b/Content.Server/Corvax/TTS/TTSSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using Content.Server._WL.Languages; //WL-Changes: Languages
+using System.Threading.Tasks;
 using Content.Server.Chat.Systems;
 using Content.Shared.Corvax.CCCVars;
 using Content.Shared.Corvax.TTS;
@@ -19,6 +20,8 @@ public sealed partial class TTSSystem : EntitySystem
     [Dependency] private readonly TTSManager _ttsManager = default!;
     [Dependency] private readonly SharedTransformSystem _xforms = default!;
     [Dependency] private readonly IRobustRandom _rng = default!;
+
+    [Dependency] private readonly LanguagesSystem _languages = default!; //WL-Changes: Languages
 
     private readonly List<string> _sampleText =
         new()
@@ -90,6 +93,17 @@ public sealed partial class TTSSystem : EntitySystem
         if (!_prototypeManager.TryIndex<TTSVoicePrototype>(voiceId, out var protoVoice))
             return;
 
+        //WL-Changes: Languages start
+        if (args.LangMessage != null)
+        {
+            if (args.LangObfusMessage != null && args.ObfuscatedMessage != null)
+                HandleLangWhisper(uid, args.Message, args.ObfuscatedMessage, args.LangMessage, args.LangObfusMessage, protoVoice.Speaker);
+            else
+                HandleLangSay(uid, args.Message, args.LangMessage, protoVoice.Speaker);
+            return;
+        }
+        //WL-Changes: Languages End
+
         if (args.ObfuscatedMessage != null)
         {
             HandleWhisper(uid, args.Message, args.ObfuscatedMessage, protoVoice.Speaker);
@@ -132,6 +146,81 @@ public sealed partial class TTSSystem : EntitySystem
             RaiseNetworkEvent(distance > ChatSystem.WhisperClearRange ? obfTtsEvent : fullTtsEvent, session);
         }
     }
+
+    //WL-Changes: Languages start
+    private async void HandleLangSay(EntityUid uid, string message, string langMessage, string speaker)
+    {
+        var fullSoundData = await GenerateTTS(message, speaker, true);
+        if (fullSoundData is null) return;
+
+        var langSoundData = await GenerateTTS(langMessage, speaker, true);
+        if (langSoundData is null) return;
+
+        var fullTtsEvent = new PlayTTSEvent(fullSoundData, GetNetEntity(uid), true);
+        var langTtsEvent = new PlayTTSEvent(langSoundData, GetNetEntity(uid), true);
+
+        var xformQuery = GetEntityQuery<TransformComponent>();
+        var sourcePos = _xforms.GetWorldPosition(xformQuery.GetComponent(uid), xformQuery);
+        var receptions = Filter.Pvs(uid).Recipients;
+        foreach (var session in receptions)
+        {
+            if (!session.AttachedEntity.HasValue) continue;
+            var listener = session.AttachedEntity.Value;
+            var xform = xformQuery.GetComponent(listener);
+            var distance = (sourcePos - _xforms.GetWorldPosition(xform, xformQuery)).Length();
+            if (distance > ChatSystem.VoiceRange * ChatSystem.VoiceRange)
+                continue;
+
+            var check = _languages.CanUnderstand(uid, listener);
+
+            if (!check && _languages.IsObfusEmoting(uid)) continue;
+            RaiseNetworkEvent(check ? langTtsEvent : fullTtsEvent, session);
+        }
+    }
+
+    private async void HandleLangWhisper(EntityUid uid, string message, string obfMessage, string langMessage, string langObfusMessage, string speaker)
+    {
+        var fullSoundData = await GenerateTTS(message, speaker, true);
+        if (fullSoundData is null) return;
+
+        var obfSoundData = await GenerateTTS(obfMessage, speaker, true);
+        if (obfSoundData is null) return;
+
+        var langFullSoundData = await GenerateTTS(langMessage, speaker, true);
+        if (langFullSoundData is null) return;
+
+        var langObfusSoundData = await GenerateTTS(langObfusMessage, speaker, true);
+        if (langObfusSoundData is null) return;
+
+        var fullTtsEvent = new PlayTTSEvent(fullSoundData, GetNetEntity(uid), true);
+        var obfTtsEvent = new PlayTTSEvent(obfSoundData, GetNetEntity(uid), true);
+
+        var langFullTtsEvent = new PlayTTSEvent(langFullSoundData, GetNetEntity(uid), true);
+        var langObfusTtsEvent = new PlayTTSEvent(langObfusSoundData, GetNetEntity(uid), true);
+
+        // TODO: Check obstacles
+        var xformQuery = GetEntityQuery<TransformComponent>();
+        var sourcePos = _xforms.GetWorldPosition(xformQuery.GetComponent(uid), xformQuery);
+        var receptions = Filter.Pvs(uid).Recipients;
+        foreach (var session in receptions)
+        {
+            if (!session.AttachedEntity.HasValue) continue;
+            var listener = session.AttachedEntity.Value;
+            var xform = xformQuery.GetComponent(listener);
+            var distance = (sourcePos - _xforms.GetWorldPosition(xform, xformQuery)).Length();
+            if (distance > ChatSystem.VoiceRange * ChatSystem.VoiceRange)
+                continue;
+
+            var check = _languages.CanUnderstand(uid, listener);
+
+            if (!check && _languages.IsObfusEmoting(uid)) continue;
+            if (check)
+                RaiseNetworkEvent(distance > ChatSystem.WhisperClearRange ? obfTtsEvent : fullTtsEvent, session);
+            else
+                RaiseNetworkEvent(distance > ChatSystem.WhisperClearRange ? langObfusTtsEvent : langFullTtsEvent, session);
+        }
+    }
+    //WL-Changes: Languages end
 
     // ReSharper disable once InconsistentNaming
     private async Task<byte[]?> GenerateTTS(string text, string speaker, bool isWhisper = false)

--- a/Content.Server/Corvax/TTS/TTSSystem.cs
+++ b/Content.Server/Corvax/TTS/TTSSystem.cs
@@ -174,7 +174,7 @@ public sealed partial class TTSSystem : EntitySystem
             var check = _languages.CanUnderstand(uid, listener);
 
             if (!check && _languages.IsObfusEmoting(uid)) continue;
-            RaiseNetworkEvent(check ? langTtsEvent : fullTtsEvent, session);
+            RaiseNetworkEvent(!check ? langTtsEvent : fullTtsEvent, session);
         }
     }
 

--- a/Content.Server/Corvax/TTS/TTSSystem.cs
+++ b/Content.Server/Corvax/TTS/TTSSystem.cs
@@ -168,7 +168,7 @@ public sealed partial class TTSSystem : EntitySystem
             var listener = session.AttachedEntity.Value;
             var xform = xformQuery.GetComponent(listener);
             var distance = (sourcePos - _xforms.GetWorldPosition(xform, xformQuery)).Length();
-            if (distance > ChatSystem.VoiceRange * ChatSystem.VoiceRange)
+            if (distance > ChatSystem.VoiceRange)
                 continue;
 
             var check = _languages.CanUnderstand(uid, listener);

--- a/Content.Server/Corvax/TTS/TTSSystem.cs
+++ b/Content.Server/Corvax/TTS/TTSSystem.cs
@@ -150,14 +150,14 @@ public sealed partial class TTSSystem : EntitySystem
     //WL-Changes: Languages start
     private async void HandleLangSay(EntityUid uid, string message, string langMessage, string speaker)
     {
-        var fullSoundData = await GenerateTTS(message, speaker, true);
+        var fullSoundData = await GenerateTTS(message, speaker);
         if (fullSoundData is null) return;
 
-        var langSoundData = await GenerateTTS(langMessage, speaker, true);
+        var langSoundData = await GenerateTTS(langMessage, speaker);
         if (langSoundData is null) return;
 
-        var fullTtsEvent = new PlayTTSEvent(fullSoundData, GetNetEntity(uid), true);
-        var langTtsEvent = new PlayTTSEvent(langSoundData, GetNetEntity(uid), true);
+        var fullTtsEvent = new PlayTTSEvent(fullSoundData, GetNetEntity(uid));
+        var langTtsEvent = new PlayTTSEvent(langSoundData, GetNetEntity(uid));
 
         var xformQuery = GetEntityQuery<TransformComponent>();
         var sourcePos = _xforms.GetWorldPosition(xformQuery.GetComponent(uid), xformQuery);


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Исправлен ТТС на языках. Теперь при не понимании языка озвучивается бессмыслица.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- wl-fix: Исправлена озвучка ТТС при непонимании языка

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language-aware chat: listeners who understand a language hear the original message; others receive obfuscated or "unknown" variants.
  * Whisper and say now respect per-listener language comprehension, applying appropriate obfuscation and formatting.
  * Language-aware TTS: voice output adapts to listener comprehension and distance for say/whisper, including obfuscated variants when not understood.
  * Improved per-listener message selection ensures consistent behavior across proximity chat, whispers, and TTS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->