### PR TITLE
Added color marks

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -452,16 +452,10 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         name = FormattedMessage.EscapeText(name);
 
-        var wrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
-            ("entityName", name),
-            ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
-            ("fontType", speech.FontId),
-            ("fontSize", speech.FontSize),
-            ("message", FormattedMessage.EscapeText(message)));
-
         //WL-Changes: Languages start
-        var obfusWrappedMessage = _languages.GetObfusWrappedMessage(message, source, name, speech);
+        var wrappedMessage = _languages.GetWrappedMessage(message, source, name, speech);
         var obfusMessage = _languages.ObfuscateMessageFromSource(message, source);
+        var obfusWrappedMessage = _languages.GetWrappedMessage(obfusMessage, source, name, speech);
 
         SendInVoiceRange(ChatChannel.Local, message, wrappedMessage, obfusWrappedMessage, source, range);
         //WL-Changes: Languages end
@@ -527,8 +521,10 @@ public sealed partial class ChatSystem : SharedChatSystem
         }
         name = FormattedMessage.EscapeText(name);
 
-        var wrappedMessage = Loc.GetString("chat-manager-entity-whisper-wrap-message",
-            ("entityName", name), ("message", FormattedMessage.EscapeText(message)));
+        //WL-Changes: Languages start
+        var color = _languages.GetColor(source);
+        var wrappedMessage = Loc.GetString("chat-manager-entity-whisper-wrap-message-lang",
+            ("entityName", name), ("message", FormattedMessage.EscapeText(message)), ("langColor", color));
 
         var wrappedobfuscatedMessage = Loc.GetString("chat-manager-entity-whisper-wrap-message",
             ("entityName", nameIdentity), ("message", FormattedMessage.EscapeText(obfuscatedMessage)));
@@ -536,9 +532,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         var wrappedUnknownMessage = Loc.GetString("chat-manager-entity-whisper-unknown-wrap-message",
             ("message", FormattedMessage.EscapeText(obfuscatedMessage)));
 
-        //WL-Changes: Languages start
         var langObfusMessage = _languages.ObfuscateMessageFromSource(message, source);
-        var obfusWrappedMessage = _languages.GetObfusWrappedMessage(message, source, name);
+        var obfusWrappedMessage = _languages.GetWrappedMessage(langObfusMessage, source, name);
         var biobfMessage = ObfuscateMessageReadability(langObfusMessage, 0.2f);
         var wrappedbiobfusMessage = Loc.GetString("chat-manager-entity-whisper-wrap-message",
             ("entityName", nameIdentity), ("message", FormattedMessage.EscapeText(biobfMessage)));

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -99,14 +99,9 @@ public sealed class RadioSystem : EntitySystem
             ? FormattedMessage.EscapeText(message)
             : message;
 
-        var wrappedMessage = Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
-            ("color", channel.Color),
-            ("fontType", speech.FontId),
-            ("fontSize", speech.FontSize),
-            ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
-            ("channel", $"\\[{channel.LocalizedName}\\]"),
-            ("name", name),
-            ("message", content));
+        //WL-Changes: Languages start
+        var wrappedMessage = _languages.GetRadioWrappedMessage(content, messageSource, name, speech, channel);
+        //WL-Changes: Languages end
 
         // most radios are relayed to chat, so lets parse the chat message beforehand
         var chat = new ChatMessage(

--- a/Content.Shared/_WL/Languages/LanguagePrototype.cs
+++ b/Content.Shared/_WL/Languages/LanguagePrototype.cs
@@ -21,6 +21,6 @@ public sealed partial class LanguagePrototype : IPrototype
     [DataField(required: true)]
     public ObfuscationMethod Obfuscation = ObfuscationMethod.Default;
 
-    [DataField]
-    public string Colour = "#000000";
+    [DataField("color")]
+    public Color Color = Color.White;
 }

--- a/Resources/Locale/ru-RU/_WL/languages/wrappers.ftl
+++ b/Resources/Locale/ru-RU/_WL/languages/wrappers.ftl
@@ -1,0 +1,8 @@
+chat-manager-entity-say-wrap-message-lang = [BubbleHeader][bold][Name]{ $entityName }[/Name][/bold][/BubbleHeader] { $verb }, [font={ $fontType } size={ $fontSize } ]"[BubbleContent][color={ $langColor }]{ $message }[/color][/BubbleContent]"[/font]
+chat-manager-entity-say-bold-wrap-message-lang = [BubbleHeader][bold][Name]{ $entityName }[/Name][/bold][/BubbleHeader] { $verb }, [font={ $fontType } size={ $fontSize }]"[BubbleContent][bold][color={ $langColor }]{ $message }[/color][/bold][/BubbleContent]"[/font]
+
+chat-manager-entity-whisper-wrap-message-lang = [font size=11][italic][BubbleHeader][Name]{ $entityName }[/Name][/BubbleHeader] шепчет,"[BubbleContent][color={ $langColor }]{ $message }[/color][/BubbleContent]"[/italic][/font]
+
+chat-radio-message-wrap-lang = [color={ $color }]{ $channel } [bold]{ $name }[/bold] { $verb }, [font={ $fontType } size={ $fontSize }]"[color={ $langColor }]{ $message }[/color]"[/font][/color]
+chat-radio-message-wrap-bold-lang = [color={ $color }]{ $channel } [bold]{ $name }[/bold] { $verb }, [font={ $fontType }
+size={ $fontSize }][bold]"[color={ $langColor }]{ $message }[/color]"[/bold][/font][/color]

--- a/Resources/Prototypes/_WL/Languages/languages.yml
+++ b/Resources/Prototypes/_WL/Languages/languages.yml
@@ -94,6 +94,7 @@
   id: SintaUnati
   name: language-unati
   description: language-unati-desc
+  color: '#ede028'
   obfuscation:
     !type:ByCharReplacementObfuscation
       replacement:
@@ -128,6 +129,7 @@
   id: OldEarth
   name: language-oldearth
   description: language-oldearth-desc
+  color: "#5fff33"
   obfuscation:
     !type:Utf16ReplacementObfuscation
       utf16start: 224
@@ -140,6 +142,7 @@
   id: Kuniluc
   name: language-vulpa
   description: language-vulpa-desc
+  color: '#cccc00'
   obfuscation:
     !type:Utf16ReplacementObfuscation
       utf16start: 224
@@ -152,6 +155,7 @@
   id: Sarengis
   name: language-sareng
   description: language-sareng-desc
+  color: '#ff644d'
   obfuscation:
     !type:Utf16ReplacementObfuscation
       utf16start: 902
@@ -164,6 +168,7 @@
   id: Weaver
   name: language-weaver
   description: language-weaver-desc
+  color: '#f5ee8c'
   obfuscation:
     !type:EmoteObfuscation
       replacement:
@@ -179,6 +184,7 @@
   id: Ternary
   name: language-ternary
   description: language-ternary-desc
+  color: '#03b5fc'
   obfuscation:
     !type:ByCharReplacementObfuscation
       replacement:
@@ -193,6 +199,7 @@
   id: RootSpeak
   name: language-rootspeak
   description: language-rootspeak-desc
+  color: '#309100'
   obfuscation:
     !type:EmoteObfuscation
       replacement:
@@ -207,6 +214,7 @@
   id: VoxPigin
   name: language-vox
   description: language-vox-desc
+  color: '#8c6500'
   obfuscation:
     !type:ByCharReplacementObfuscation
       replacement:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Языкам добавлены цветовые обозначения

## Почему / Баланс
Теперь будет понятно, кто когда и на каком языке говорит

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<img width="270" height="294" alt="image" src="https://github.com/user-attachments/assets/8c30b0aa-50ba-40b4-b52a-32d5911af194" />
<img width="408" height="294" alt="image" src="https://github.com/user-attachments/assets/7aae6f67-b7ca-4143-bd6a-2b37a3e328cd" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
:cl:
- wl-add: Добавлены цветовые обозначения для языков.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Language-aware chat and radio messages with per-language colors for say/whisper/radio.
  * Per-listener comprehension: unintelligible radio/chat appears obfuscated, intelligible remains clear.
  * Enhanced whisper formatting with language context and color accents.
  * Added Russian localization strings for language-based chat wrappers.
* Refactor
  * Unified message-wrapping logic across chat and radio for consistent presentation.
* Chores
  * Assigned colors to multiple in-game languages for consistent theming across messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->