### PR TITLE
Pill from greed

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/slime_cat_parts.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/slime_cat_parts.yml
@@ -3,7 +3,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  sponsorOnly: false # WL-Changes: Pill from greed # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_cat_outer
@@ -15,7 +15,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  sponsorOnly: false # WL-Changes: Pill from greed # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: slime_tail_cat_wag # Corvax-Sponsors
@@ -25,7 +25,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  sponsorOnly: false # WL-Changes: Pill from greed # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_stubby_outer
@@ -37,7 +37,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  sponsorOnly: false # WL-Changes: Pill from greed # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_curled_outer
@@ -49,7 +49,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  sponsorOnly: false # WL-Changes: Pill from greed # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
     state: ears_slime_torn_outer
@@ -61,7 +61,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  sponsorOnly: false # WL-Changes: Pill from greed # Corvax-Sponsors
   sprites:
     - sprite: Corvax/Mobs/Customization/slime_cat_parts.rsi
       state: slime_tail_cat_wag_stripes_prime

--- a/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/slime_fox_parts.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/slime_fox_parts.yml
@@ -3,7 +3,7 @@
   bodyPart: HeadTop
   markingCategory: HeadTop
   speciesRestriction: [SlimePerson]
-  sponsorOnly: true # Corvax-Sponsors
+  sponsorOnly: false # WL-Changes: Pill from greed # Corvax-Sponsors
   sprites:
   - sprite: Corvax/Mobs/Customization/slime_fox_parts.rsi
     state: ears_slime_fox_outer


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
У маркингов слаймолюдов удалена спонсорская зависимость.

## Почему / Баланс
Репозиторий ВЛ попил таблеток от жадности.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры.-->
:cl:
- wl-fix: У маркингов слаймолюдов удалена спонсорская зависимость.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Slime cat markings (ears and tail variations) are now available to all players instead of just sponsors.
  * Slime fox ears marking is now available to all players instead of just sponsors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->