### PR TITLE
Gamepresets changes

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -124,7 +124,7 @@ namespace Content.Server.Voting.Managers
 
             var vote = CreateVote(options);
 
-            TimeoutStandardVote(StandardVoteType.EvacuationShuttle, TimeSpan.FromSeconds(_cfg.GetCVar(WLCCVars.VoteShuttleTimeout)));
+            TimeoutStandardVote(StandardVoteType.EvacuationShuttle, TimeSpan.FromSeconds(_cfg.GetCVar(WLCVars.VoteShuttleTimeout)));
 
             vote.OnFinished += (_, args) =>
             {

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -76,6 +76,7 @@ namespace Content.Server.Voting.Managers
                     break;
                 // WL-Changes-start
                 case StandardVoteType.EvacuationShuttle:
+                    timeoutVote = false; // Allows the timeout to be updated manually in the create method
                     CreateVoteShuttleEvac(initiator);
                     break;
                 // WL-Changes-end
@@ -122,6 +123,8 @@ namespace Content.Server.Voting.Managers
             WirePresetVoteInitiator(options, initiator);
 
             var vote = CreateVote(options);
+
+            TimeoutStandardVote(StandardVoteType.EvacuationShuttle, TimeSpan.FromSeconds(_cfg.GetCVar(WLCCVars.VoteShuttleTimeout)));
 
             vote.OnFinished += (_, args) =>
             {

--- a/Content.Shared/_WL/CCVars/WLCCVars.Vote.cs
+++ b/Content.Shared/_WL/CCVars/WLCCVars.Vote.cs
@@ -25,4 +25,10 @@ public sealed partial class WLCVars
     /// </summary>
     public static readonly CVarDef<int> VoteShuttleTimer =
         CVarDef.Create("vote.evacuation_shuttle_vote_time", 40, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Задержка между голосованиями за шаттл.
+    /// </summary>
+    public static readonly CVarDef<float> VoteShuttleTimeout =
+        CVarDef.Create("vote.evacuation_shittle_vote_timeout", 1800f, CVar.SERVERONLY);
 }

--- a/Content.Shared/_WL/CCVars/WLCCVars.Vote.cs
+++ b/Content.Shared/_WL/CCVars/WLCCVars.Vote.cs
@@ -30,5 +30,5 @@ public sealed partial class WLCVars
     /// Задержка между голосованиями за шаттл.
     /// </summary>
     public static readonly CVarDef<float> VoteShuttleTimeout =
-        CVarDef.Create("vote.evacuation_shittle_vote_timeout", 1800f, CVar.SERVERONLY);
+        CVarDef.Create("vote.evacuation_shuttle_vote_timeout", 1800f, CVar.SERVERONLY);
 }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -697,7 +697,7 @@
     - id: SolarPanelDamageVariationPass
     - id: SolarPanelEmptyVariationPass
     - id: BasicDecalDirtVariationPass
-    - id: BasicDecalGraffitiVariationPass
+    # - id: BasicDecalGraffitiVariationPass # WL-Changes: Disable graffities
     - id: BasicDecalBurnsVariationPass
       prob: 0.50
       orGroup: monospaceDecals

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -80,6 +80,7 @@
   name: extended-title
   showInVote: true #WL gamepreset vote changes
   description: extended-description
+  minPlayers: 5 # WL-Changes: Station calmdown
   rules:
   - BasicStationEventScheduler
   #- MeteorSwarmScheduler
@@ -123,6 +124,7 @@
   name: secret-title
   showInVote: true
   description: secret-description
+  minPlayers: 5 # WL-Changes: Station calmdown
   rules:
     - Secret
 


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Измнены геймрулы и чёт ещё

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
:cl:
- wl-add: Добавлен минимум игроков у режима расширенного в размере 7 штук.
- wl-remove: Удалены раундстарт граффити.
- wl-tweak: Изменена задержка у голосования за шаттл до получаса.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated timeout configuration for evacuation shuttle votes.

* **Configuration**
  * Extended and Secret game presets now require a minimum of 5 players to start.

* **Style**
  * Disabled graffiti decal variation effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->