### PR TITLE
Devour popups to comp

### DIFF
--- a/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
@@ -131,4 +131,33 @@ public sealed partial class ChangelingDevourComponent : Component
     public float DevourPreventionPercentageThreshold = 0.1f;
 
     public override bool SendOnlyToOwner => true;
+
+    //WL-Changes: Custom devour popups start
+    [DataField]
+    public string AttemptFailedRottingPopup = "changeling-devour-attempt-failed-rotting";
+
+    [DataField]
+    public string AttemptFailedProtectedPopup = "changeling-devour-attempt-failed-protected";
+
+    [DataField]
+    public string BeginWindupSelfPopup = "changeling-devour-begin-windup-self";
+
+    [DataField]
+    public string BeginWindupOthersPopup = "changeling-devour-begin-windup-others";
+
+    [DataField]
+    public string BeginConsumeSelfPopup = "changeling-devour-begin-consume-self";
+
+    [DataField]
+    public string BeginConsumeOthersPopup = "changeling-devour-begin-consume-others";
+
+    [DataField]
+    public string ConsumeFailedNotDeadPopup = "changeling-devour-consume-failed-not-dead";
+
+    [DataField]
+    public string ConsumeCompleteSelfPopup = "changeling-devour-consume-complete-self";
+
+    [DataField]
+    public string ConsumeCompleteOthersPopup = "changeling-devour-consume-complete-self";
+    //WL-Changes: Custom devour popups end
 }

--- a/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
@@ -133,31 +133,31 @@ public sealed partial class ChangelingDevourComponent : Component
     public override bool SendOnlyToOwner => true;
 
     //WL-Changes: Custom devour popups start
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string AttemptFailedRottingPopup = "changeling-devour-attempt-failed-rotting";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string AttemptFailedProtectedPopup = "changeling-devour-attempt-failed-protected";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string BeginWindupSelfPopup = "changeling-devour-begin-windup-self";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string BeginWindupOthersPopup = "changeling-devour-begin-windup-others";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string BeginConsumeSelfPopup = "changeling-devour-begin-consume-self";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string BeginConsumeOthersPopup = "changeling-devour-begin-consume-others";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string ConsumeFailedNotDeadPopup = "changeling-devour-consume-failed-not-dead";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public string ConsumeCompleteSelfPopup = "changeling-devour-consume-complete-self";
 
-    [DataField]
-    public string ConsumeCompleteOthersPopup = "changeling-devour-consume-complete-self";
+    [DataField, AutoNetworkedField]
+    public string ConsumeCompleteOthersPopup = "changeling-devour-consume-complete-others";
     //WL-Changes: Custom devour popups end
 }

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -133,13 +133,15 @@ public sealed class ChangelingDevourSystem : EntitySystem
 
         if (HasComp<RottingComponent>(target))
         {
-            _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-rotting"), args.Performer, args.Performer, PopupType.Medium);
+        //WL-Changes: Devour custom popups start
+            _popupSystem.PopupClient(Loc.GetString(ent.Comp.AttemptFailedRottingPopup), args.Performer, args.Performer, PopupType.Medium);
             return;
         }
 
         if (IsTargetProtected(target, ent))
         {
-            _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-protected"), ent, ent, PopupType.Medium);
+            _popupSystem.PopupClient(Loc.GetString(ent.Comp.AttemptFailedProtectedPopup), ent, ent, PopupType.Medium);
+        //WL-Changes: Devour custom popups end
             return;
         }
 
@@ -159,8 +161,10 @@ public sealed class ChangelingDevourSystem : EntitySystem
             DuplicateCondition = DuplicateConditions.None,
         });
 
-        var selfMessage = Loc.GetString("changeling-devour-begin-windup-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
-        var othersMessage = Loc.GetString("changeling-devour-begin-windup-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
+        //WL-Changes: Devour custom popups start
+        var selfMessage = Loc.GetString(ent.Comp.BeginWindupSelfPopup, ("user", Identity.Entity(ent.Owner, EntityManager)));
+        var othersMessage = Loc.GetString(ent.Comp.BeginWindupOthersPopup, ("user", Identity.Entity(ent.Owner, EntityManager)));
+        //WL-Changes: Devour custom popups end
         _popupSystem.PopupPredicted(
             selfMessage,
             othersMessage,
@@ -180,8 +184,10 @@ public sealed class ChangelingDevourSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        var selfMessage = Loc.GetString("changeling-devour-begin-consume-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
-        var othersMessage = Loc.GetString("changeling-devour-begin-consume-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
+        //WL-Changes: Devour custom popups start
+        var selfMessage = Loc.GetString(ent.Comp.BeginConsumeSelfPopup, ("user", Identity.Entity(ent.Owner, EntityManager)));
+        var othersMessage = Loc.GetString(ent.Comp.BeginConsumeOthersPopup, ("user", Identity.Entity(ent.Owner, EntityManager)));
+        //WL-Changes: Devour custom popups end
         _popupSystem.PopupPredicted(
             selfMessage,
             othersMessage,
@@ -234,12 +240,16 @@ public sealed class ChangelingDevourSystem : EntitySystem
         if (!_mobState.IsDead((EntityUid)target))
         {
             _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner):player}  unsuccessfully devoured {ToPrettyString(args.Target):player}'s identity");
-            _popupSystem.PopupClient(Loc.GetString("changeling-devour-consume-failed-not-dead"), args.User, args.User, PopupType.Medium);
+        //WL-Changes: Devour custom popups start
+            _popupSystem.PopupClient(Loc.GetString(ent.Comp.ConsumeFailedNotDeadPopup), args.User, args.User, PopupType.Medium);
+        //WL-Changes: Devour custom popups end
             return;
         }
 
-        var selfMessage = Loc.GetString("changeling-devour-consume-complete-self", ("user", Identity.Entity(args.User, EntityManager)));
-        var othersMessage = Loc.GetString("changeling-devour-consume-complete-others", ("user", Identity.Entity(args.User, EntityManager)));
+        //WL-Changes: Devour custom popups start
+        var selfMessage = Loc.GetString(ent.Comp.ConsumeCompleteSelfPopup, ("user", Identity.Entity(args.User, EntityManager)));
+        var othersMessage = Loc.GetString(ent.Comp.ConsumeCompleteSelfPopup, ("user", Identity.Entity(args.User, EntityManager)));
+        //WL-Changes: Devour custom popups end
         _popupSystem.PopupPredicted(
             selfMessage,
             othersMessage,

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -248,7 +248,7 @@ public sealed class ChangelingDevourSystem : EntitySystem
 
         //WL-Changes: Devour custom popups start
         var selfMessage = Loc.GetString(ent.Comp.ConsumeCompleteSelfPopup, ("user", Identity.Entity(args.User, EntityManager)));
-        var othersMessage = Loc.GetString(ent.Comp.ConsumeCompleteSelfPopup, ("user", Identity.Entity(args.User, EntityManager)));
+        var othersMessage = Loc.GetString(ent.Comp.ConsumeCompleteOthersPopup, ("user", Identity.Entity(args.User, EntityManager)));
         //WL-Changes: Devour custom popups end
         _popupSystem.PopupPredicted(
             selfMessage,

--- a/Resources/Prototypes/_WL/Maps/Whitelist/wl_bagel.yml
+++ b/Resources/Prototypes/_WL/Maps/Whitelist/wl_bagel.yml
@@ -1,83 +1,83 @@
 # Special Map for Corvax - Whitelist
-- type: gameMap
-  id: CorvaxWLBagel
-  mapName: 'Багель'
-  mapPath: /Maps/_WL/wl_bagel.yml
-  maxRandomOffset: 0
-  randomRotation: false
-  minPlayers: 5
-  maxPlayers: 30
-  stations:
-    CorvaxBagel:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: '{0} Багель {1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: 'AM'
-        - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/_WL/Shuttles/wl_bagel_evac.yml
-        - type: StationJobs
-          availableJobs:
-
-            #  command
-            Captain: [ 1, 1 ]
-            IAA: [ 1, 1 ]
-            Quartermaster: [ 1, 1 ]
-            ChiefEngineer: [ 1, 1 ]
-            ChiefMedicalOfficer: [ 1, 1 ]
-            ResearchDirector: [ 1, 1 ]
-            HeadOfSecurity: [ 1, 1 ]
-            HeadOfPersonnel: [ 1, 1 ]
-            Adjutant: [ 1, 1 ]
-
-            # cargo
-            SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 2, 2 ]
-
-            # engineering
-            AtmosphericTechnician: [ 3, 3 ]
-            SeniorEngineer: [ 1, 1 ]
-            StationEngineer: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ]
-
-            # medical
-            MedicalDoctor: [ 2, 2 ]
-            SeniorPhysician: [ 1, 1 ]
-            MedicalIntern: [ 2, 2 ]
-            Psychologist: [ 1, 1 ]
-            Paramedic: [ 1, 1 ]
-            Chemist: [ 2, 2 ]
-
-            # science
-            SeniorResearcher: [ 1, 1 ]
-            Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 2, 2 ]
-
-            # security
-            Warden: [ 1, 1 ]
-            SecurityOfficer: [ 2, 2 ]
-            SeniorOfficer: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
-            Detective: [ 1, 1 ]
-            Brigmedic: [ 1, 1 ]
-            Pilot: [ 2, 2 ]
-
-            # service
-            Bartender: [ 2, 2 ]
-            Botanist: [ 2, 2 ]
-            Chaplain: [ 1, 1 ]
-            Chef: [ 2, 2 ]
-            Clown: [ 1, 1 ]
-            Janitor: [ 2, 2 ]
-            Librarian: [ 1, 1 ]
-            Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
-            ServiceWorker: [ 2, 2 ]
-            Passenger: [ -1, -1 ]
-
-            #silicon
-            Borg: [ 2, 2 ]
-            StationAi: [ 1, 1 ]
+# - type: gameMap
+#   id: CorvaxWLBagel
+#   mapName: 'Багель'
+#   mapPath: /Maps/_WL/wl_bagel.yml
+#   maxRandomOffset: 0
+#   randomRotation: false
+#   minPlayers: 5
+#   maxPlayers: 30
+#   stations:
+#     CorvaxBagel:
+#       stationProto: StandardNanotrasenStation
+#       components:
+#         - type: StationNameSetup
+#           mapNameTemplate: '{0} Багель {1}'
+#           nameGenerator:
+#             !type:NanotrasenNameGenerator
+#             prefixCreator: 'AM'
+#         - type: StationEmergencyShuttle
+#           emergencyShuttlePath: /Maps/_WL/Shuttles/wl_bagel_evac.yml
+#         - type: StationJobs
+#           availableJobs:
+#
+#             #  command
+#             Captain: [ 1, 1 ]
+#             IAA: [ 1, 1 ]
+#             Quartermaster: [ 1, 1 ]
+#             ChiefEngineer: [ 1, 1 ]
+#             ChiefMedicalOfficer: [ 1, 1 ]
+#             ResearchDirector: [ 1, 1 ]
+#             HeadOfSecurity: [ 1, 1 ]
+#             HeadOfPersonnel: [ 1, 1 ]
+#             Adjutant: [ 1, 1 ]
+#
+#             # cargo
+#             SalvageSpecialist: [ 3, 3 ]
+#             CargoTechnician: [ 2, 2 ]
+#
+#             # engineering
+#             AtmosphericTechnician: [ 3, 3 ]
+#             SeniorEngineer: [ 1, 1 ]
+#             StationEngineer: [ 2, 2 ]
+#             TechnicalAssistant: [ 2, 2 ]
+#
+#             # medical
+#             MedicalDoctor: [ 2, 2 ]
+#             SeniorPhysician: [ 1, 1 ]
+#             MedicalIntern: [ 2, 2 ]
+#             Psychologist: [ 1, 1 ]
+#             Paramedic: [ 1, 1 ]
+#             Chemist: [ 2, 2 ]
+#
+#             # science
+#             SeniorResearcher: [ 1, 1 ]
+#             Scientist: [ 3, 3 ]
+#             ResearchAssistant: [ 2, 2 ]
+#
+#             # security
+#             Warden: [ 1, 1 ]
+#             SecurityOfficer: [ 2, 2 ]
+#             SeniorOfficer: [ 1, 1 ]
+#             SecurityCadet: [ 2, 2 ]
+#             Detective: [ 1, 1 ]
+#             Brigmedic: [ 1, 1 ]
+#             Pilot: [ 2, 2 ]
+#
+#             # service
+#             Bartender: [ 2, 2 ]
+#             Botanist: [ 2, 2 ]
+#             Chaplain: [ 1, 1 ]
+#             Chef: [ 2, 2 ]
+#             Clown: [ 1, 1 ]
+#             Janitor: [ 2, 2 ]
+#             Librarian: [ 1, 1 ]
+#             Mime: [ 1, 1 ]
+#             Musician: [ 1, 1 ]
+#             Reporter: [ 1, 1 ]
+#             ServiceWorker: [ 2, 2 ]
+#             Passenger: [ -1, -1 ]
+#
+#             #silicon
+#             Borg: [ 2, 2 ]
+#             StationAi: [ 1, 1 ]


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Devour popups to comp

## Почему / Баланс
мне для ивента

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: Теперь попапы при пожирании генокрадом можно менять в компоненте.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable devour notification messages for attempt failures (rotting, protected), windup (self, others), consume start (self, others), failed consume when target isn't dead, and consume completion (self, others); notifications are now configurable and localizable.
* **Chores**
  * Disabled the CorvaxWLBagel map configuration in the whitelist resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->