### PR TITLE
Маркинги унатхов (не все) людям

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/reptilian.yml
@@ -81,11 +81,13 @@
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_angler
 
+ # WL human and android with reptilian markings start
+
 - type: marking
   id: LizardHornsCurled
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_curled
@@ -94,7 +96,7 @@
   id: LizardHornsRam
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_ram
@@ -103,7 +105,7 @@
   id: LizardHornsShort
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_short
@@ -112,10 +114,12 @@
   id: LizardHornsSimple
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_simple
+
+ # WL human and android with reptilian markings end
 
 - type: marking
   id: LizardHornsDouble
@@ -126,16 +130,20 @@
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_double
 
+ # WL human and android with reptilian markings start
+
 - type: marking
   id: LizardTailSmooth
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: tail_smooth_primary
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: tail_smooth_secondary
+
+ # WL human and android with reptilian markings end
 
 - type: marking
   id: LizardTailLarge
@@ -287,11 +295,13 @@
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: r_leg_tiger
 
+ # WL human and android with reptilian markings start
+
 - type: marking
   id: LizardHornsArgali
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_argali
@@ -300,7 +310,7 @@
   id: LizardHornsAyrshire
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_ayrshire
@@ -309,7 +319,7 @@
   id: LizardHornsMyrsore
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_myrsore
@@ -318,7 +328,7 @@
   id: LizardHornsBighorn
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian, Cischi]
+  speciesRestriction: [Reptilian, Cischi, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_bighorn
@@ -327,10 +337,12 @@
   id: LizardHornsDemonic
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, Human, Android]
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_demonic
+
+ # WL human and android with reptilian markings end
 
 - type: marking
   id: LizardHornsKoboldEars


### PR DESCRIPTION
## Описание PR
Добавила 9 маркингов рогов людям и андроидам
И 1 гладкий хвост 
Рога выглядят отвратительно правда но тоже ничего

## Почему / Баланс
В массовой культуре очень популярны девочки с рожками и ящеродевочки почему бы не удовлетворить желание поиграть за милашек

## Технические детали
Human, Android в рестрикшнах

## Медиа
<img width="1910" height="613" alt="image" src="https://github.com/user-attachments/assets/0d21d032-4e58-48ed-b4bd-ef4ce458773d" />

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-add: Добавлены 9 маркингов рогов и 1 хвоста унатхов людям и анадроидам


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reptilian markings, including various horn styles and tail variants, are now available for Human and Android species in addition to existing species.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->