### PR TITLE
Добавлены галстуки

### DIFF
--- a/Resources/Prototypes/_WL/Catalog/VendingMachines/Inventories/corp.yml
+++ b/Resources/Prototypes/_WL/Catalog/VendingMachines/Inventories/corp.yml
@@ -2,6 +2,8 @@
   id: CorpDrobeInventory
   startingInventory:
     # Neck
+    ClothingNeckTieRed: 4
+    ClothingNeckTieDet: 4
     ClothingNeckTieGray: 4
     ClothingNeckTieBlue: 4
     ClothingNeckTieGreen: 4


### PR DESCRIPTION
## Описание PR
В Корп-о-Мат добавлены чёрный и красный галстуки.

## Почему / Баланс
Их забыли добавить ранее.

## Медиа
<img width="398" height="348" alt="image" src="https://github.com/user-attachments/assets/3489e397-1481-4b7e-816a-891ff77b2b09" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**

:cl:
- wl-add: В Корп-о-Мат добавлен галстук детектива (4 штуки)
- wl-add: В Корп-о-Мат добавлен красный галстук (4 штуки)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new neck tie options to vending machine inventory. Red neck ties and detective-style neck ties are now available in select vending machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->