### PR TITLE
Отключение ниндзи из геймрулов

### DIFF
--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -77,13 +77,15 @@
           - !type:MaxRuleOccurenceCondition
           - !type:RoundDurationCondition
             min: 900 # 15 minutes
-        - id: NinjaSpawn
-          weight: 20
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:MaxRuleOccurenceCondition
-          - !type:RoundDurationCondition
-            min: 900 # 15 minutes
+        # WL-Changes-Start
+        #- id: NinjaSpawn
+        #  weight: 20
+        #  conditions:
+        #  - !type:HasBudgetCondition
+        #  - !type:MaxRuleOccurenceCondition
+        #  - !type:RoundDurationCondition
+        #    min: 900 # 15 minutes
+        # WL-Changes-End
         - id: ParadoxCloneSpawn
           weight: 25
           conditions:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -40,7 +40,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: DragonSpawn
-    - id: NinjaSpawn
+    # - id: NinjaSpawn #WL-Changes
     - id: ParadoxCloneSpawn
     - id: SleeperAgents
     - id: ZombieOutbreak


### PR DESCRIPTION
## Описание PR
Ниндзя теперь не будет спавниться самостоятельно. Геймрул все еще доступен для щитспавна

## Почему / Баланс
таск

## Технические детали
коментирование юмльки

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-remove: Ниндзя больше не может спавниться (Временно)

