### PR TITLE
HSV это для извращенцев

### DIFF
--- a/Content.Client/Humanoid/EyeColorPicker.cs
+++ b/Content.Client/Humanoid/EyeColorPicker.cs
@@ -27,7 +27,8 @@ public sealed class EyeColorPicker : Control
         AddChild(vBox);
 
         vBox.AddChild(_colorSelectors = new ColorSelectorSliders());
-        _colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
+        //_colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
+        _colorSelectors.SelectorType = ColorSelectorSliders.ColorSelectorType.Rgb; // WL-changes - Default-RGB
 
         _colorSelectors.OnColorChanged += ColorValueChanged;
     }

--- a/Content.Client/Humanoid/LayerMarkingItem.xaml.cs
+++ b/Content.Client/Humanoid/LayerMarkingItem.xaml.cs
@@ -170,7 +170,8 @@ public sealed partial class LayerMarkingItem : BoxContainer, ISearchableControl
             ColorsContainer.AddChild(container);
 
             var selector = new ColorSelectorSliders();
-            selector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
+            //selector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv;
+            selector.SelectorType = ColorSelectorSliders.ColorSelectorType.Rgb; // WL-changes - Default-RGB
 
             var label = _markingPrototype.Sprites[i] switch
             {

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -308,7 +308,8 @@ namespace Content.Client.Lobby.UI
             };
 
             RgbSkinColorContainer.AddChild(_rgbSkinColorSelector = new ColorSelectorSliders());
-            _rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
+            //_rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Hsv; // defaults color selector to HSV
+            _rgbSkinColorSelector.SelectorType = ColorSelectorSliders.ColorSelectorType.Rgb; // WL-changes - Default-RGB
             _rgbSkinColorSelector.OnColorChanged += _ =>
             {
                 OnSkinColorOnValueChanged();


### PR DESCRIPTION
## Описание PR
Теперь ты изначально будешь красить маркинг/глаза/цвет кожи итд в РГБ, а не в HSV

## Почему / Баланс
удобство. таск

## Технические детали
где надо изменять `ColorSelectorSliders.ColorSelectorType.Hsv` в `ColorSelectorSliders.ColorSelectorType.Rgb` 

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-tweak: Выбор цветов в кастомизации теперь изначально будет в RGB



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the color picker interface for eye color, marking layer colors, and skin tone selection in humanoid profile customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->