### PR TITLE
один фармацефт

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -3,8 +3,6 @@
   name: job-name-chemist
   description: job-description-chemist
   playTimeTracker: JobChemist
-  subnames:
-  - Male: фармацевт
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
У фармацефта больше нет подроли фармацефт. Она теперь одна, как например у тех супервайзера

## Почему / Баланс
Таск + отсутствие бредика

## Технические детали
полное удаление сабнейма

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-fix: Убран дубликат роли у фармацефта.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected job definition by removing an unnecessary alternate name field from the Chemist role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->