### PR TITLE
Фикс спецовки атмоса

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/suits.yml
@@ -37,7 +37,8 @@
         shader: unshaded
       - state: equipped-OUTERCLOTHING-unshaded
         shader: shaded
-      outerClothing-reptilian:
+      # WL-Changes-start
+      outerClothing-reptilian: 
       - state: equipped-OUTERCLOTHING-reptilian
       - state: equipped-OUTERCLOTHING-reptilian-unshaded
         shader: unshaded
@@ -49,4 +50,5 @@
         shader: unshaded
       - state: equipped-OUTERCLOTHING-vox-unshaded
         shader: shaded
+      # WL-Changes-end
       # Это так светооражающие элементы сделаны. Подробности в файле с ClothingOuterVestHazard

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/suits.yml
@@ -19,7 +19,7 @@
       sprite: Corvax/Clothing/OuterClothing/Coats/disco.rsi
     - type: Clothing
       sprite: Corvax/Clothing/OuterClothing/Coats/disco.rsi
-      
+
 - type: entity
   parent: ClothingOuterStorageBase
   id: ClothingAtmosphericsOveralls
@@ -36,5 +36,17 @@
       - state: equipped-OUTERCLOTHING-unshaded
         shader: unshaded
       - state: equipped-OUTERCLOTHING-unshaded
+        shader: shaded
+      outerClothing-reptilian:
+      - state: equipped-OUTERCLOTHING-reptilian
+      - state: equipped-OUTERCLOTHING-reptilian-unshaded
+        shader: unshaded
+      - state: equipped-OUTERCLOTHING-reptilian-unshaded
+        shader: shaded
+      outerClothing-vox:
+      - state: equipped-OUTERCLOTHING-vox
+      - state: equipped-OUTERCLOTHING-vox-unshaded
+        shader: unshaded
+      - state: equipped-OUTERCLOTHING-vox-unshaded
         shader: shaded
       # Это так светооражающие элементы сделаны. Подробности в файле с ClothingOuterVestHazard


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Теперь она нормально отображается на лизардах и курицах

## Почему / Баланс
Баг, до светоотражающих элементов такого не было

## Технические детали
ямлмаксинг

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-fix: Спецовка атмосов отображается корректно на унатхах и воксах


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added visual appearance support for Reptilian and Vox characters in atmospheric overalls with shaded and unshaded rendering variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->