### PR TITLE
Шлюзы адьютанта и репортёра

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -69,6 +69,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "Maintenance",
         "Medical",
         "Quartermaster",
+        "Reporter", // WL-Reporter-Changes
         "Research",
         "ResearchDirector",
         "Salvage",

--- a/Resources/Locale/ru-RU/_WL/entities/objects/devices/electronics/door_access.ftl
+++ b/Resources/Locale/ru-RU/_WL/entities/objects/devices/electronics/door_access.ftl
@@ -1,0 +1,3 @@
+ent-DoorElectronicsAdjutant = { ent-DoorElectronics }
+    .desc = { ent-DoorElectronics.desc }
+    .suffix = Адъютант, Закрыт

--- a/Resources/Locale/ru-RU/_WL/entities/objects/devices/electronics/door_access.ftl
+++ b/Resources/Locale/ru-RU/_WL/entities/objects/devices/electronics/door_access.ftl
@@ -1,3 +1,7 @@
 ent-DoorElectronicsAdjutant = { ent-DoorElectronics }
     .desc = { ent-DoorElectronics.desc }
     .suffix = Адъютант, Закрыт
+
+ent-DoorElectronicsReporter = { ent-DoorElectronics }
+    .desc = { ent-DoorElectronics.desc }
+    .suffix = Репортёр, Закрыт

--- a/Resources/Locale/ru-RU/_WL/entities/structures/doors/airlocks/access.ftl
+++ b/Resources/Locale/ru-RU/_WL/entities/structures/doors/airlocks/access.ftl
@@ -1,0 +1,9 @@
+ent-AirlockAdjutantLocked = { ent-AirlockCommand }
+    .desc = { ent-AirlockCommand.desc }
+    .suffix = Адъютант, Закрыт
+ent-AirlockAdjutantGlassLocked = { ent-AirlockCommandGlass }
+    .desc = { ent-AirlockCommandGlass.desc }
+    .suffix = Адъютант, Закрыт
+ent-AirlockMaintAdjutantLocked = { ent-AirlockAdjutantLocked }
+    .desc = { ent-AirlockAdjutantLocked.desc }
+    .suffix = { ent-AirlockAdjutantLocked.suffix }

--- a/Resources/Locale/ru-RU/_WL/entities/structures/doors/airlocks/access.ftl
+++ b/Resources/Locale/ru-RU/_WL/entities/structures/doors/airlocks/access.ftl
@@ -7,3 +7,13 @@ ent-AirlockAdjutantGlassLocked = { ent-AirlockCommandGlass }
 ent-AirlockMaintAdjutantLocked = { ent-AirlockAdjutantLocked }
     .desc = { ent-AirlockAdjutantLocked.desc }
     .suffix = { ent-AirlockAdjutantLocked.suffix }
+
+ent-AirlockReporterLocked = { ent-Airlock }
+    .desc = { ent-Airlock.desc }
+    .suffix = Репортёр, Закрыт
+ent-AirlockReporterGlassLocked = { ent-AirlockGlass }
+    .desc = { ent-AirlockGlass.desc }
+    .suffix = Репортёр, Закрыт
+ent-AirlockMaintReporterLocked = { ent-AirlockReporterLocked }
+    .desc = { ent-AirlockReporterLocked.desc }
+    .suffix = { ent-AirlockReporterLocked.suffix }

--- a/Resources/Locale/ru-RU/_WL/entities/structures/doors/windoors/windoor.ftl
+++ b/Resources/Locale/ru-RU/_WL/entities/structures/doors/windoors/windoor.ftl
@@ -1,3 +1,7 @@
 ent-WindoorSecureAdjutantLocked = { ent-WindoorSecureCommandLocked }
     .desc = { ent-WindoorSecureCommandLocked.desc }
     .suffix = Адъютант, Закрыт
+
+ent-WindoorReporterLocked = { ent-WindoorServiceLocked }
+    .desc = { ent-WindoorServiceLocked.desc }
+    .suffix = Репортёр, Закрыт

--- a/Resources/Locale/ru-RU/_WL/entities/structures/doors/windoors/windoor.ftl
+++ b/Resources/Locale/ru-RU/_WL/entities/structures/doors/windoors/windoor.ftl
@@ -1,0 +1,3 @@
+ent-WindoorSecureAdjutantLocked = { ent-WindoorSecureCommandLocked }
+    .desc = { ent-WindoorSecureCommandLocked.desc }
+    .suffix = Адъютант, Закрыт

--- a/Resources/Locale/ru-RU/_WL/prototypes/access/accesses.ftl
+++ b/Resources/Locale/ru-RU/_WL/prototypes/access/accesses.ftl
@@ -1,1 +1,2 @@
 id-card-access-level-adjutant = Адъютант
+id-card-access-level-reporter = Репортёр

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -35,6 +35,7 @@
   - GenpopEnter
   - GenpopLeave
   - Adjutant #WL-Changes: Adjutant
+  - Reporter # WL-Reporter-Changes
 
 - type: accessGroup
   id: General

--- a/Resources/Prototypes/Access/service.yml
+++ b/Resources/Prototypes/Access/service.yml
@@ -42,3 +42,4 @@
   - Theatre
   - Chapel
   - Lawyer
+  - Reporter # WL-Reporter-Changes

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -46,6 +46,7 @@
   - Kitchen
   - Chapel
   - Hydroponics
+  - Reporter # WL-Reporter-Changes
   - External
   - Cryogenics
   # I mean they'll give themselves the rest of the access levels *anyways*.

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -17,6 +17,7 @@
   access:
   - Service
   - Maintenance
+  - Reporter # WL-Reporter-changes
   # WL-Skills-start
   bonusSkillPoints: 23
   defaultSkills:

--- a/Resources/Prototypes/_WL/Access/service.yml
+++ b/Resources/Prototypes/_WL/Access/service.yml
@@ -1,0 +1,3 @@
+- type: accessLevel
+  id: Reporter
+  name: id-card-access-level-reporter

--- a/Resources/Prototypes/_WL/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_WL/Entities/Objects/Devices/Electronics/door_access.yml
@@ -1,0 +1,7 @@
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsAdjutant
+  suffix: Adjutant, Locked
+  components:
+  - type: AccessReader
+    access: [["Adjutant"]]

--- a/Resources/Prototypes/_WL/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_WL/Entities/Objects/Devices/Electronics/door_access.yml
@@ -5,3 +5,11 @@
   components:
   - type: AccessReader
     access: [["Adjutant"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsReporter
+  suffix: Reporter, Locked
+  components:
+  - type: AccessReader
+    access: [["Reporter"]]

--- a/Resources/Prototypes/_WL/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_WL/Entities/Structures/Doors/Airlocks/access.yml
@@ -22,3 +22,28 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+- type: entity
+  parent: Airlock
+  id: AirlockReporterLocked
+  suffix: Reporter, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
+
+- type: entity
+  parent: AirlockGlass
+  id: AirlockReporterGlassLocked
+  suffix: Reporter, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]
+
+- type: entity
+  parent: AirlockReporterLocked
+  id: AirlockMaintReporterLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi

--- a/Resources/Prototypes/_WL/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_WL/Entities/Structures/Doors/Airlocks/access.yml
@@ -1,0 +1,24 @@
+- type: entity
+  parent: AirlockCommand
+  id: AirlockAdjutantLocked
+  suffix: Adjutant, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAdjutant ]
+
+- type: entity
+  parent: AirlockCommandGlass
+  id: AirlockAdjutantGlassLocked
+  suffix: Adjutant, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAdjutant ]
+
+- type: entity
+  parent: AirlockAdjutantLocked
+  id: AirlockMaintAdjutantLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi

--- a/Resources/Prototypes/_WL/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_WL/Entities/Structures/Doors/Windoors/windoor.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureAdjutantLocked
+  suffix: Adjutant, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAdjutant ]

--- a/Resources/Prototypes/_WL/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_WL/Entities/Structures/Doors/Windoors/windoor.yml
@@ -6,3 +6,12 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsAdjutant ]
+
+- type: entity
+  parent: WindoorServiceLocked
+  id: WindoorReporterLocked
+  suffix: Reporter, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsReporter ]


### PR DESCRIPTION
## Описание PR
глаза подними выше, там написано

## Почему / Баланс
Личные шлюзы чтобы главы не перлись в личную комнату адьютанту + таск
Аналогично репортеру

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
yaml и совсем чучут фтльки. для репортера в компаче консоли айди карт добавлена его должность

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
<img width="362" height="890" alt="image" src="https://github.com/user-attachments/assets/dfe7f89e-eec5-4d8b-9e04-ac1aef9c045d" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-add: Добавлены шлюзы и раздвижное бронеокно с доступами адьютанта
- wl-add: Добавлен доступ репортера и шлюзы к нему

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Adjutant- and Reporter-restricted variants for door electronics, airlocks, windoors, and their maintenance versions, each with distinct naming and access behavior.
  * Introduced a new Reporter access level and integrated it into access groups and consoles.

* **Localization**
  * Added Russian translations for all new Adjutant and Reporter door variants and the Reporter access-level label.

* **Chores**
  * Updated role/job access lists to include the Reporter permission where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->