### PR TITLE
Редизайн окна персонажа

### DIFF
--- a/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml
+++ b/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml
@@ -6,12 +6,12 @@
     <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True" Margin="5">
         <!-- Спрайт персонажа -->
         <PanelContainer StyleClasses="BackgroundPanelDark" Margin="5">
-            <RichTextLabel Name="SpriteLabel"
+            <Label Name="SpriteTextLabel"
                            Text="{Loc 'character-information-ui-sprite'}"
-                           Margin="0 5 0 0"
                            VerticalAlignment="Top"
+                           Margin="0 10 0 0"
                            HorizontalAlignment="Center"/>
-            <BoxContainer Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Center" MinWidth="300" Margin="0,0,8,0">
+            <BoxContainer Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Center" MinWidth="250">
                 <SpriteView Name="CharSprite" Scale="6 6" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                 <RichTextLabel Name="NameLabel" Margin="0 5 0 0" HorizontalAlignment="Center"/>
             </BoxContainer>

--- a/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml
+++ b/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml
@@ -1,37 +1,52 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                      xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:style="clr-namespace:Content.Client.Stylesheets"
-                      Title="{Loc 'character-information-ui-title'}" MinSize="700 350" Resizable="True">
-    <TabContainer Name="Tabs" HorizontalExpand="True" Margin="4">
-        <BoxContainer Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Center">
-            <SpriteView Name="CharSprite" Scale="4 4" VerticalAlignment="Top" HorizontalAlignment="Center"/>
-            <RichTextLabel Name="NameLabel" Margin="0 5 0 0" HorizontalAlignment="Center"/>
-        </BoxContainer>
-
-        <ScrollContainer HorizontalExpand="True" HScrollEnabled="False" MinWidth="400">
-            <BoxContainer Orientation="Vertical">
-                <Label
-                    Name="FlavorTextLabel"
-                    HorizontalExpand="True"
-                    Margin="0 10 0 0"
-                    HorizontalAlignment="Center" />
-                <RichTextLabel Name="FlavorText" HorizontalExpand="True" Margin="8" />
+                      xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
+                      Title="{Loc 'character-information-ui-title'}" MinSize="950 600" Resizable="True">
+    <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True" Margin="5">
+        <!-- Спрайт персонажа -->
+        <PanelContainer StyleClasses="BackgroundPanelDark" Margin="5">
+            <RichTextLabel Name="SpriteLabel"
+                           Text="{Loc 'character-information-ui-sprite'}"
+                           Margin="0 5 0 0"
+                           VerticalAlignment="Top"
+                           HorizontalAlignment="Center"/>
+            <BoxContainer Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Center" MinWidth="300" Margin="0,0,8,0">
+                <SpriteView Name="CharSprite" Scale="6 6" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                <RichTextLabel Name="NameLabel" Margin="0 5 0 0" HorizontalAlignment="Center"/>
             </BoxContainer>
-        </ScrollContainer>
+        </PanelContainer>
 
-        <ScrollContainer HorizontalExpand="True" HScrollEnabled="False" MinWidth="400">
-            <BoxContainer Orientation="Vertical">
-                <Label
-                    Name="OocTextLabel"
-                    HorizontalExpand="True"
-                    Text="{Loc 'character-information-ui-ooc-text'}"
-                    Margin="0 10 0 0"
-                    HorizontalAlignment="Center" />
-                <RichTextLabel Name="OocText" HorizontalExpand="True" Margin="8" />
+        <PanelContainer StyleClasses="BackgroundPanelDark" HorizontalExpand="True" VerticalExpand="True" Margin="5">
+            <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" StyleClasses="BackgroundPanelDark">
+                <!-- Флавор -->
+                <ScrollContainer HorizontalExpand="True" VerticalExpand="True" HScrollEnabled="False" MinWidth="550">
+                    <BoxContainer Orientation="Vertical">
+                        <Label
+                            Name="FlavorTextLabel"
+                            Text="{Loc 'character-information-ui-flavor-text'}"
+                            HorizontalExpand="True"
+                            Margin="0 10 0 0"
+                            HorizontalAlignment="Center" />
+                        <RichTextLabel Name="FlavorText" HorizontalExpand="True" Margin="10" />
+                    </BoxContainer>
+                </ScrollContainer>
+
+                <customControls:VSeparator StyleClasses="LowDivider" Margin="10 10 10 0"/>
+
+                <!-- ООС -->
+                <ScrollContainer HorizontalExpand="True" VerticalExpand="True" HScrollEnabled="False" MinWidth="550" StyleClasses="BackgroundPanelDark">
+                    <BoxContainer Orientation="Vertical">
+                        <Label
+                            Name="OocTextLabel"
+                            HorizontalExpand="True"
+                            Text="{Loc 'character-information-ui-ooc-text'}"
+                            Margin="0 10 0 0"
+                            HorizontalAlignment="Center" />
+                        <RichTextLabel Name="OocText" HorizontalExpand="True" Margin="8" />
+                    </BoxContainer>
+                </ScrollContainer>
             </BoxContainer>
-        </ScrollContainer>
-
-    </TabContainer>
+        </PanelContainer>
+    </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml.cs
+++ b/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml.cs
@@ -19,8 +19,6 @@ public sealed partial class CharacterInformationWindow : FancyWindow
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
-
-        SpriteLabel.Text = Loc.GetString("character-information-ui-sprite");
     }
 
     protected override void FrameUpdate(FrameEventArgs args)
@@ -36,25 +34,13 @@ public sealed partial class CharacterInformationWindow : FancyWindow
         CharSprite.SetEntity(_entity.GetEntity(state.Uid));
         NameLabel.SetMarkup($"[bold]{state.CharacterName}[/bold]");
 
-        if (!string.IsNullOrEmpty(state.FlavorText))
-        {
-            FlavorText.SetMessage(state.FlavorText);
-            FlavorTextLabel.Text = Loc.GetString("character-information-ui-flavor-text");
-        }
-        else
-        {
-            FlavorText.SetMessage(Loc.GetString("character-information-ui-no-flavor-text"));
-        }
+        FlavorText.SetMessage(!string.IsNullOrEmpty(state.FlavorText)
+            ? state.FlavorText
+            : Loc.GetString("character-information-ui-no-flavor-text"));
 
-        if (!string.IsNullOrEmpty(state.OocText))
-        {
-            OocText.SetMessage(state.OocText);
-            OocTextLabel.Text = Loc.GetString("character-information-ui-ooc-text");
-        }
-        else
-        {
-            OocText.SetMessage(Loc.GetString("character-information-ui-no-ooc-text"));
-        }
+        OocText.SetMessage(!string.IsNullOrEmpty(state.OocText)
+            ? state.OocText
+            : Loc.GetString("character-information-ui-no-ooc-text"));
 
         SetWidth = Size.X + 0.1f;
     }

--- a/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml.cs
+++ b/Content.Client/_WL/CharacterInformation/CharacterInformationWindow.xaml.cs
@@ -20,9 +20,7 @@ public sealed partial class CharacterInformationWindow : FancyWindow
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
 
-        Tabs.SetTabTitle(0, Loc.GetString("character-information-ui-sprite"));
-        Tabs.SetTabTitle(1, Loc.GetString("character-information-ui-flavor-text"));
-        Tabs.SetTabTitle(2, Loc.GetString("character-information-ui-ooc-text"));
+        SpriteLabel.Text = Loc.GetString("character-information-ui-sprite");
     }
 
     protected override void FrameUpdate(FrameEventArgs args)
@@ -41,23 +39,21 @@ public sealed partial class CharacterInformationWindow : FancyWindow
         if (!string.IsNullOrEmpty(state.FlavorText))
         {
             FlavorText.SetMessage(state.FlavorText);
-            FlavorTextLabel.Text = Loc.GetString("character-information-ui-flavor-text") + ":";
+            FlavorTextLabel.Text = Loc.GetString("character-information-ui-flavor-text");
         }
         else
         {
-            FlavorText.SetMessage("");
-            FlavorTextLabel.Text = Loc.GetString("character-information-ui-no-flavor-text");
+            FlavorText.SetMessage(Loc.GetString("character-information-ui-no-flavor-text"));
         }
 
         if (!string.IsNullOrEmpty(state.OocText))
         {
             OocText.SetMessage(state.OocText);
-            OocTextLabel.Text = Loc.GetString("character-information-ui-ooc-text") + ":";
+            OocTextLabel.Text = Loc.GetString("character-information-ui-ooc-text");
         }
         else
         {
-            OocText.SetMessage("");
-            OocTextLabel.Text = Loc.GetString("character-information-ui-no-ooc-text");
+            OocText.SetMessage(Loc.GetString("character-information-ui-no-ooc-text"));
         }
 
         SetWidth = Size.X + 0.1f;


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Теперь окно описания персонажа совмещает в себе предыдущие вкладки. Вместо 3-х вкладок со спрайтом, флавором и ООС информацией есть одна вкладка со всем нужным.

## Почему / Баланс
Удобство игроков. Все находится в одном месте, так что не требуется переключаться между вкладками. Ну и еще это таск

## Технические детали
Постучаться головой об стену пока делаешь верстку. Слегка переписана логика окошка.

## Медиа
Было:
<img width="700" height="347" alt="image" src="https://github.com/user-attachments/assets/18c04120-7938-415b-98a2-deec154ceeb6" />
Стало
<img width="959" height="593" alt="image" src="https://github.com/user-attachments/assets/d57d2492-0848-4b63-8e60-7b5f074170c6" />
<img width="972" height="608" alt="image" src="https://github.com/user-attachments/assets/440476d2-e414-4a22-b8be-c5be924b4fa7" />


## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-tweak: Окно описания персонажа объединило в себе предыдущие вкладки

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Character Information window with a horizontal two-panel layout replacing the previous tab-based interface
  * Character sprite moved to dedicated left panel with improved centering and visibility
  * Flavor text and OOC information reorganized in right panel for better usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->