### PR TITLE
Карпоакулы для дракона

### DIFF
--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -36,5 +36,13 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     public float SpawnCooldown = 30f;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("spawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string SpawnPrototype = "MobCarpDragon";
+    public string CarpSpawnPrototype = "MobCarpDragon"; // WL-Changes: SpawnPrototype -> CarpSpawnPrototype
+
+    //WL-Changes-Start
+    [ViewVariables(VVAccess.ReadWrite), DataField("spawnSharkChance")]
+    public float SharkSpawnChance = 0.1f;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("spawnShark", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string SharkSpawnPrototype = "MobSharkDragon";
+    //WL-Changes-End
 }

--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -12,6 +12,7 @@ using System.Numerics;
 using Content.Shared.Damage.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.GameStates;
+using Robust.Shared.Random; //WL-Changes
 using Robust.Shared.Utility;
 
 namespace Content.Server.Dragon;
@@ -27,6 +28,7 @@ public sealed partial class DragonRiftSystem : EntitySystem
     [Dependency] private NavMapSystem _navMap = default!;
     [Dependency] private NPCSystem _npc = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private IRobustRandom _random = default!; //WL-Changes
 
     public override void Initialize()
     {
@@ -88,7 +90,13 @@ public sealed partial class DragonRiftSystem : EntitySystem
             if (comp.SpawnAccumulator > comp.SpawnCooldown)
             {
                 comp.SpawnAccumulator -= comp.SpawnCooldown;
-                var ent = Spawn(comp.SpawnPrototype, xform.Coordinates);
+                //WL-Changes-Start
+                //var ent = Spawn(comp.SpawnPrototype, xform.Coordinates);
+                var ent = Spawn(_random.Next(comp.SharkSpawnChance) == 0
+                    ? comp.SharkSpawnPrototype
+                    : comp.CarpSpawnPrototype,
+                    xform.Coordinates);
+                //WL-Changes-End
 
                 // Update their look to match the leader.
                 if (TryComp<RandomSpriteComponent>(comp.Dragon, out var randomSprite))

--- a/Resources/Locale/ru-RU/_WL/entities/mobs/npcs/carp.ftl
+++ b/Resources/Locale/ru-RU/_WL/entities/mobs/npcs/carp.ftl
@@ -1,0 +1,3 @@
+ent-MobSharkDragon = { ent-MobShark }
+    .desc = { ent-MobShark.desc }
+    .suffix = ВыводокДракона

--- a/Resources/Locale/ru-RU/_WL/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/ru-RU/_WL/ghost/roles/ghost-role-component.ftl
@@ -1,3 +1,6 @@
 ghost-role-information-pulse-demon-name = Токовый дух
 ghost-role-information-pulse-demon-description = Взламывайте лкп и высасывайте энергию, чтобы получить полный энергетиеский контроль над станцией!
 ghost-role-information-pulse-demon-rules = Вам разрешено высасывать энергию из [color=green]любых[/color] приборов. Вам разрешено убивать(пытаться убить) игроков, которые попытаются помешать вашей трапезе.
+
+ghost-role-information-sentient-shark-name = Разумная акула
+ghost-role-information-sentient-shark-description = Помогите дракону наводнить станцию карпами и акулами!

--- a/Resources/Prototypes/_WL/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/_WL/Mobs/NPCs/carp.yml
@@ -1,0 +1,25 @@
+- type: entity
+  name: space shark
+  id: MobSharkDragon
+  suffix: DragonBrood
+  parent: MobShark
+  components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-sentient-shark-name
+    description: ghost-role-information-sentient-shark-description
+    rules: ghost-role-information-space-dragon-summoned-carp-rules
+    mindRoles:
+    - MindRoleGhostRoleTeamAntagonistFlock
+  - type: GhostTakeoverAvailable
+  - type: HTN
+    rootTask:
+      task: DragonCarpCompound
+  - type: Flammable
+    damage:
+      types: {}
+  - type: Temperature
+  - type: TemperatureDamage
+    heatDamageThreshold: 1200


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Карпоакулы спавнятся из разломов дракона с шансом 10%

## Почему / Баланс
дракон слабенький. ну и акулы у него должны быть, не только же ему карпами повелевать

## Технические детали
добавлено 2 параметра в DragonRiftComponent - SharkSpawnPrototype и SharkSpawnChance. Первое отвечает за прототип акулы, второе за шанс. 
в системе dragonrift прописан рандомный шанс на спавн либо карпа, либо акулы. 

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-add: Разломы дракона теперь могут спавнить акул с 10% шансом
