### PR TITLE
Фикс паспортов

### DIFF
--- a/Content.Client/_WL/Passports/UI/ChameleonPassportBoundUserInterface.cs
+++ b/Content.Client/_WL/Passports/UI/ChameleonPassportBoundUserInterface.cs
@@ -23,7 +23,7 @@ namespace Content.Client._WL.Passports.UI
             _window.OnNameChanged += OnNameChanged;
             _window.OnSpeciesChanged += OnSpeciesChanged;
             _window.OnGenderChanged += OnGenderChanged;
-            _window.OnYOBChanged += OnYOBChanged;
+            _window.OnDateOfBirthChanged += OnDateOfBirthChanged;
             _window.OnHeightChanged += OnHeightChanged;
             _window.OnPIDChanged += OnPIDChanged;
         }
@@ -43,11 +43,10 @@ namespace Content.Client._WL.Passports.UI
             SendMessage(new ChameleonPassportGenderChangedMessage(newGender));
         }
 
-        private void OnYOBChanged(string newYOB)
+        private void OnDateOfBirthChanged(string newDateOfBirth)
         {
-            SendMessage(new ChameleonPassportYOBChangedMessage(newYOB));
+            SendMessage(new ChameleonPassportDateOfBirthChangedMessage(newDateOfBirth));
         }
-
 
         private void OnHeightChanged(string newHeight)
         {
@@ -73,7 +72,7 @@ namespace Content.Client._WL.Passports.UI
             _window.SetCurrentName(cast.CurrentName);
             _window.SetCurrentSpecies(cast.CurrentSpecies);
             _window.SetCurrentGender(cast.CurrentGender);
-            _window.SetCurrentYOB(cast.CurrentYOB);
+            _window.SetCurrentDateOfBirth(cast.CurrentDateOfBirth);
             _window.SetCurrentHeight(cast.CurrentHeight);
             _window.SetCurrentPID(cast.CurrentPID);
         }

--- a/Content.Client/_WL/Passports/UI/ChameleonPassportWindow.xaml
+++ b/Content.Client/_WL/Passports/UI/ChameleonPassportWindow.xaml
@@ -14,8 +14,8 @@
         <Label Name="CurrentGender" Text="{Loc 'chameleon-passport-current-gender'}" />
         <LineEdit Name="GenderLineEdit" />
 
-        <Label Name="CurrentYOB" Text="{Loc 'chameleon-passport-current-year-of-birth'}" />
-        <LineEdit Name="YOBLineEdit" />
+        <Label Name="CurrentDateOfBirth" Text="{Loc 'chameleon-passport-current-date-of-birth'}" />
+        <LineEdit Name="DateOfBirthLineEdit" />
 
         <Label Name="CurrentHeight" Text="{Loc 'chameleon-passport-current-height'}" />
         <LineEdit Name="HeightLineEdit" />

--- a/Content.Client/_WL/Passports/UI/ChameleonPassportWindow.xaml.cs
+++ b/Content.Client/_WL/Passports/UI/ChameleonPassportWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace Content.Client._WL.Passports.UI
         public event Action<string>? OnNameChanged;
         public event Action<string>? OnSpeciesChanged;
         public event Action<string>? OnGenderChanged;
-        public event Action<string>? OnYOBChanged;
+        public event Action<string>? OnDateOfBirthChanged;
         public event Action<string>? OnHeightChanged;
         public event Action<string>? OnPIDChanged;
 
@@ -28,8 +28,8 @@ namespace Content.Client._WL.Passports.UI
             GenderLineEdit.OnTextEntered += e => OnGenderChanged?.Invoke(e.Text);
             GenderLineEdit.OnFocusExit += e => OnGenderChanged?.Invoke(e.Text);
 
-            YOBLineEdit.OnTextEntered += e => OnYOBChanged?.Invoke(e.Text);
-            YOBLineEdit.OnFocusExit += e => OnYOBChanged?.Invoke(e.Text);
+            DateOfBirthLineEdit.OnTextEntered += e => OnDateOfBirthChanged?.Invoke(e.Text);
+            DateOfBirthLineEdit.OnFocusExit += e => OnDateOfBirthChanged?.Invoke(e.Text);
 
             HeightLineEdit.OnTextEntered += e => OnHeightChanged?.Invoke(e.Text);
             HeightLineEdit.OnFocusExit += e => OnHeightChanged?.Invoke(e.Text);
@@ -53,9 +53,9 @@ namespace Content.Client._WL.Passports.UI
             GenderLineEdit.Text = gender;
         }
 
-        public void SetCurrentYOB(string yearOfBirth)
+        public void SetCurrentDateOfBirth(string dateOfBirth)
         {
-            YOBLineEdit.Text = yearOfBirth;
+            DateOfBirthLineEdit.Text = dateOfBirth;
         }
 
         public void SetCurrentHeight(string height)

--- a/Content.Server/_WL/Passports/Systems/ChameleonPassportSystem.cs
+++ b/Content.Server/_WL/Passports/Systems/ChameleonPassportSystem.cs
@@ -32,13 +32,12 @@ namespace Content.Server._WL.Passports.Systems
                 return;
 
             var state = new ChameleonPassportBoundUserInterfaceState(
-                passport.DisplayName ?? "",
-                passport.DisplaySpecies ?? "",
-                passport.DisplayGender ?? "",
-                passport.DisplayDateOfBirth ?? "",
-                passport.DisplayHeight ?? "",
-                passport.DisplayPID ?? ""
-                );
+                passport.DisplayName,
+                passport.DisplaySpecies,
+                passport.DisplayGender,
+                passport.DisplayDateOfBirth,
+                passport.DisplayHeight,
+                passport.DisplayPID);
             _uiSystem.SetUiState(uid, ChameleonPassportUiKey.Key, state);
         }
 

--- a/Content.Server/_WL/Passports/Systems/ChameleonPassportSystem.cs
+++ b/Content.Server/_WL/Passports/Systems/ChameleonPassportSystem.cs
@@ -18,7 +18,7 @@ namespace Content.Server._WL.Passports.Systems
             SubscribeLocalEvent<ChameleonPassportComponent, ChameleonPassportNameChangedMessage>(OnNameChanged);
             SubscribeLocalEvent<ChameleonPassportComponent, ChameleonPassportSpeciesChangedMessage>(OnSpeciesChanged);
             SubscribeLocalEvent<ChameleonPassportComponent, ChameleonPassportGenderChangedMessage>(OnGenderChanged);
-            SubscribeLocalEvent<ChameleonPassportComponent, ChameleonPassportYOBChangedMessage>(OnYOBChanged);
+            SubscribeLocalEvent<ChameleonPassportComponent, ChameleonPassportDateOfBirthChangedMessage>(OnDateOfBirthChanged);
             SubscribeLocalEvent<ChameleonPassportComponent, ChameleonPassportHeightChangedMessage>(OnHeightChanged);
             SubscribeLocalEvent<ChameleonPassportComponent, ChameleonPassportPIDChangedMessage>(OnPIDChanged);
         }
@@ -31,8 +31,14 @@ namespace Content.Server._WL.Passports.Systems
             if (!TryComp<PassportComponent>(uid, out var passport))
                 return;
 
-            var state = new ChameleonPassportBoundUserInterfaceState(passport.DisplayName ?? "", passport.DisplaySpecies ?? "", passport.DisplayGender ?? "",
-                                                                     passport.DisplayHeight ?? "", passport.DisplayYearOfBirth ?? "", passport.DisplayPID ?? "");
+            var state = new ChameleonPassportBoundUserInterfaceState(
+                passport.DisplayName ?? "",
+                passport.DisplaySpecies ?? "",
+                passport.DisplayGender ?? "",
+                passport.DisplayDateOfBirth ?? "",
+                passport.DisplayHeight ?? "",
+                passport.DisplayPID ?? ""
+                );
             _uiSystem.SetUiState(uid, ChameleonPassportUiKey.Key, state);
         }
 
@@ -60,12 +66,12 @@ namespace Content.Server._WL.Passports.Systems
             _passportSystem.TryChangeGenderTitle(uid, args.Gender, passport);
         }
 
-        private void OnYOBChanged(EntityUid uid, ChameleonPassportComponent comp, ChameleonPassportYOBChangedMessage args)
+        private void OnDateOfBirthChanged(EntityUid uid, ChameleonPassportComponent comp, ChameleonPassportDateOfBirthChangedMessage args)
         {
             if (!TryComp<PassportComponent>(uid, out var passport))
                 return;
 
-            _passportSystem.TryChangeYOBTitle(uid, args.YOB, passport);
+            _passportSystem.TryChangeDateOfBirthTitle(uid, args.DateOfBirth, passport);
         }
 
         private void OnHeightChanged(EntityUid uid, ChameleonPassportComponent comp, ChameleonPassportHeightChangedMessage args)

--- a/Content.Server/_WL/Passports/Systems/NationalitySystem.cs
+++ b/Content.Server/_WL/Passports/Systems/NationalitySystem.cs
@@ -16,23 +16,22 @@ public sealed partial class NationalitySystem : EntitySystem
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
     }
 
-    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args) =>
+    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args)
+    {
         ApplyNationality(args.Mob, args.Profile);
+    }
 
-    public void ApplyNationality(EntityUid uid, HumanoidCharacterProfile profile)
+    private void ApplyNationality(EntityUid uid, HumanoidCharacterProfile profile)
     {
         var nationalityId = profile.Confederation;
 
         if (!_prototype.TryIndex<ConfederationRecordsPrototype>(nationalityId, out var confederationRecordsPrototype))
-        {
-            Log.Warning($"Nationality '{nationalityId}' not found!");
             return;
-        }
 
         AddNationality(uid, confederationRecordsPrototype);
     }
 
-    public void AddNationality(EntityUid uid, ConfederationRecordsPrototype confederationRecordsPrototype)
+    private void AddNationality(EntityUid uid, ConfederationRecordsPrototype confederationRecordsPrototype)
     {
         foreach (var special in confederationRecordsPrototype.Special)
         {

--- a/Content.Shared/_WL/Passports/Components/PassportComponent.cs
+++ b/Content.Shared/_WL/Passports/Components/PassportComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class PassportComponent : Component
     public string DisplayGender = string.Empty;
 
     [DataField, AutoNetworkedField]
-    public string DisplayYearOfBirth = string.Empty;
+    public string DisplayDateOfBirth = string.Empty;
 
     [DataField, AutoNetworkedField]
     public string DisplayHeight = string.Empty;

--- a/Content.Shared/_WL/Passports/Systems/SharedChameleonPassportSystem.cs
+++ b/Content.Shared/_WL/Passports/Systems/SharedChameleonPassportSystem.cs
@@ -1,20 +1,16 @@
-using Content.Shared.Administration.Logs;
 using Content.Shared._WL.Passports.Components;
-using Content.Shared.CCVar;
-using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._WL.Passports.Systems
 {
     public abstract class SharedChameleonPassportSystem : EntitySystem
     {
-        private int _maxNameLength = 32;
-        private int _maxSpeciesLength = 15;
-        private int _maxGenderLength = 11;
-        private int _maxYOBLength = 4;
-        private int _maxHeightLength = 3;
-        private int _maxPIDLength = 17;
+        private const int MaxNameLength = 32;
+        private const int MaxSpeciesLength = 15;
+        private const int MaxGenderLength = 11;
+        private const int MaxDateOfBirthLength = 24;
+        private const int MaxHeightLength = 3;
+        private const int MaxPIDLength = 17;
 
         public bool TryChangeNameTitle(EntityUid uid, string? nameTitle, PassportComponent? passport = null)
         {
@@ -24,8 +20,8 @@ namespace Content.Shared._WL.Passports.Systems
             nameTitle = nameTitle?.Trim();
             if (string.IsNullOrWhiteSpace(nameTitle))
                 nameTitle = string.Empty;
-            else if (nameTitle.Length > _maxNameLength)
-                nameTitle = nameTitle[.._maxNameLength];
+            else if (nameTitle.Length > MaxNameLength)
+                nameTitle = nameTitle[..MaxNameLength];
 
             if (passport.DisplayName == nameTitle)
                 return true;
@@ -43,8 +39,8 @@ namespace Content.Shared._WL.Passports.Systems
             speciesTitle = speciesTitle?.Trim();
             if (string.IsNullOrWhiteSpace(speciesTitle))
                 speciesTitle = string.Empty;
-            else if (speciesTitle.Length > _maxSpeciesLength)
-                speciesTitle = speciesTitle[.._maxSpeciesLength];
+            else if (speciesTitle.Length > MaxSpeciesLength)
+                speciesTitle = speciesTitle[..MaxSpeciesLength];
 
             if (passport.DisplaySpecies == speciesTitle)
                 return true;
@@ -62,8 +58,8 @@ namespace Content.Shared._WL.Passports.Systems
             genderTitle = genderTitle?.Trim();
             if (string.IsNullOrWhiteSpace(genderTitle))
                 genderTitle = string.Empty;
-            else if (genderTitle.Length > _maxGenderLength)
-                genderTitle = genderTitle[.._maxGenderLength];
+            else if (genderTitle.Length > MaxGenderLength)
+                genderTitle = genderTitle[..MaxGenderLength];
 
             if (passport.DisplayGender == genderTitle)
                 return true;
@@ -73,7 +69,7 @@ namespace Content.Shared._WL.Passports.Systems
             return true;
         }
 
-        public bool TryChangeYOBTitle(EntityUid uid, string? yobTitle, PassportComponent? passport = null)
+        public bool TryChangeDateOfBirthTitle(EntityUid uid, string? yobTitle, PassportComponent? passport = null)
         {
             if (!Resolve(uid, ref passport))
                 return false;
@@ -81,12 +77,12 @@ namespace Content.Shared._WL.Passports.Systems
             yobTitle = yobTitle?.Trim();
             if (string.IsNullOrWhiteSpace(yobTitle))
                 yobTitle = string.Empty;
-            else if (yobTitle.Length > _maxYOBLength)
-                yobTitle = yobTitle[.._maxYOBLength];
+            else if (yobTitle.Length > MaxDateOfBirthLength)
+                yobTitle = yobTitle[..MaxDateOfBirthLength];
 
-            if (passport.DisplayYearOfBirth == yobTitle)
+            if (passport.DisplayDateOfBirth == yobTitle)
                 return true;
-            passport.DisplayYearOfBirth = yobTitle;
+            passport.DisplayDateOfBirth = yobTitle;
             Dirty(uid, passport);
 
             return true;
@@ -100,8 +96,8 @@ namespace Content.Shared._WL.Passports.Systems
             heightTitle = heightTitle?.Trim();
             if (string.IsNullOrWhiteSpace(heightTitle))
                 heightTitle = string.Empty;
-            else if (heightTitle.Length > _maxHeightLength)
-                heightTitle = heightTitle[.._maxHeightLength];
+            else if (heightTitle.Length > MaxHeightLength)
+                heightTitle = heightTitle[..MaxHeightLength];
 
             if (passport.DisplayHeight == heightTitle) // предполагаем, что DisplayHeight тоже string
                 return true;
@@ -119,8 +115,8 @@ namespace Content.Shared._WL.Passports.Systems
             pidTitle = pidTitle?.Trim();
             if (string.IsNullOrWhiteSpace(pidTitle))
                 pidTitle = string.Empty;
-            else if (pidTitle.Length > _maxPIDLength)
-                pidTitle = pidTitle[.._maxPIDLength];
+            else if (pidTitle.Length > MaxPIDLength)
+                pidTitle = pidTitle[..MaxPIDLength];
 
             if (passport.DisplayPID == pidTitle)
                 return true;
@@ -145,90 +141,56 @@ namespace Content.Shared._WL.Passports.Systems
     /// Represents an <see cref="ChameleonPassportComponent"/> state that can be sent to the client
     /// </summary>
     [Serializable, NetSerializable]
-    public sealed class ChameleonPassportBoundUserInterfaceState : BoundUserInterfaceState
+    public sealed class ChameleonPassportBoundUserInterfaceState(
+        string currentName,
+        string currentSpecies,
+        string currentGender,
+        string currentDateOfBirth,
+        string currentHeight,
+        string currentPid)
+        : BoundUserInterfaceState
     {
-        public string CurrentName { get; }
-        public string CurrentSpecies { get; }
-        public string CurrentGender { get; }
-        public string CurrentYOB { get; }
-        public string CurrentHeight { get; }
-        public string CurrentPID { get; }
-
-        public ChameleonPassportBoundUserInterfaceState(string currentName, string currentSpecies, string currentGender,
-                                                        string currentYOB, string currentHeight, string currentPID)
-        {
-            CurrentName = currentName;
-            CurrentSpecies = currentSpecies;
-            CurrentGender = currentGender;
-            CurrentYOB = currentYOB;
-            CurrentHeight = currentHeight;
-            CurrentPID = currentPID;
-        }
+        public string CurrentName { get; } = currentName;
+        public string CurrentSpecies { get; } = currentSpecies;
+        public string CurrentGender { get; } = currentGender;
+        public string CurrentDateOfBirth { get; } = currentDateOfBirth;
+        public string CurrentHeight { get; } = currentHeight;
+        public string CurrentPID { get; } = currentPid;
     }
 
     [Serializable, NetSerializable]
-    public sealed class ChameleonPassportNameChangedMessage : BoundUserInterfaceMessage
+    public sealed class ChameleonPassportNameChangedMessage(string name) : BoundUserInterfaceMessage
     {
-        public string Name { get; }
-
-        public ChameleonPassportNameChangedMessage(string name)
-        {
-            Name = name;
-        }
+        public string Name { get; } = name;
     }
 
     [Serializable, NetSerializable]
-    public sealed class ChameleonPassportSpeciesChangedMessage : BoundUserInterfaceMessage
+    public sealed class ChameleonPassportSpeciesChangedMessage(string species) : BoundUserInterfaceMessage
     {
-        public string Species { get; }
-
-        public ChameleonPassportSpeciesChangedMessage(string species)
-        {
-            Species = species;
-        }
+        public string Species { get; } = species;
     }
 
     [Serializable, NetSerializable]
-    public sealed class ChameleonPassportGenderChangedMessage : BoundUserInterfaceMessage
+    public sealed class ChameleonPassportGenderChangedMessage(string gender) : BoundUserInterfaceMessage
     {
-        public string Gender { get; }
-
-        public ChameleonPassportGenderChangedMessage(string gender)
-        {
-            Gender = gender;
-        }
+        public string Gender { get; } = gender;
     }
 
     [Serializable, NetSerializable]
-    public sealed class ChameleonPassportYOBChangedMessage : BoundUserInterfaceMessage
+    public sealed class ChameleonPassportDateOfBirthChangedMessage(string date) : BoundUserInterfaceMessage
     {
-        public string YOB { get; }
-
-        public ChameleonPassportYOBChangedMessage(string yob)
-        {
-            YOB = yob;
-        }
+        public string DateOfBirth { get; } = date;
     }
 
     [Serializable, NetSerializable]
-    public sealed class ChameleonPassportHeightChangedMessage : BoundUserInterfaceMessage
+    public sealed class ChameleonPassportHeightChangedMessage(string height) : BoundUserInterfaceMessage
     {
-        public string Height { get; }
-
-        public ChameleonPassportHeightChangedMessage(string height)
-        {
-            Height = height;
-        }
+        public string Height { get; } = height;
     }
 
     [Serializable, NetSerializable]
-    public sealed class ChameleonPassportPIDChangedMessage : BoundUserInterfaceMessage
+    public sealed class ChameleonPassportPIDChangedMessage(string pid) : BoundUserInterfaceMessage
     {
-        public string PID { get; }
-
-        public ChameleonPassportPIDChangedMessage(string pid)
-        {
-            PID = pid;
-        }
+        public string PID { get; } = pid;
     }
 }

--- a/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
@@ -28,7 +28,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
     [Dependency] private SharedTransformSystem _sharedTransformSystem = default!;
     [Dependency] private ISharedAdminLogManager _adminLogManager = default!;
 
-    public int CurrentYear = DateTime.Today.Year + 849;
+    private readonly int _currentYear = DateTime.Today.Year + 849;
     private const string NoConfederationId = "NoConfederation";
     private const string PIDChars = "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789";
 
@@ -58,7 +58,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
         args.PushText(Loc.GetString("passport-species", ("species", component.DisplaySpecies)), 49);
         args.PushText(Loc.GetString("passport-gender", ("gender", component.DisplayGender)), 48);
         args.PushText(Loc.GetString("passport-height", ("height", component.DisplayHeight)), 47);
-        args.PushText(Loc.GetString("passport-year-of-birth", ("year", component.DisplayYearOfBirth)), 47);
+        args.PushText(Loc.GetString("passport-date-of-birth", ("date", component.DisplayDateOfBirth)), 47);
         args.PushText(Loc.GetString("passport-pid", ("pid", component.DisplayPID)), 46);
     }
 
@@ -69,7 +69,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
         SpawnPassportForPlayer(ev.Mob, profile, ev.JobId);
     }
 
-    public void SpawnPassportForPlayer(EntityUid mob, HumanoidCharacterProfile profile, string? jobId)
+    private void SpawnPassportForPlayer(EntityUid mob, HumanoidCharacterProfile profile, string? jobId)
     {
         if (ProhibitedJobs.Any(job => jobId == job))
             return;
@@ -111,8 +111,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
         }
     }
 
-
-    public void UpdatePassportProfile(Entity<PassportComponent> passport, HumanoidCharacterProfile profile)
+    private void UpdatePassportProfile(Entity<PassportComponent> passport, HumanoidCharacterProfile profile)
     {
         passport.Comp.OwnerProfile = profile;
 
@@ -127,7 +126,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
             _ => Loc.GetString("passport-identity-gender-person")
         };
         passport.Comp.DisplayHeight = profile.Height.ToString();
-        passport.Comp.DisplayYearOfBirth = (CurrentYear - profile.Age).ToString();
+        passport.Comp.DisplayDateOfBirth = profile.DateOfBirth != "" ? profile.DateOfBirth : $"xx.xx.{(_currentYear - profile.Age).ToString()}";
         passport.Comp.DisplayPID = GenerateIdentityString(
             profile.Name + profile.Height + profile.Age + profile.Height + profile.FlavorText
         );

--- a/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared._WL.Passports.Components;
 using Content.Shared._WL.Passports.Events;
 using Content.Shared._WL.Records;
@@ -30,6 +31,13 @@ public sealed partial class SharedPassportSystem : EntitySystem
     public int CurrentYear = DateTime.Today.Year + 849;
     private const string NoConfederationId = "NoConfederation";
     private const string PIDChars = "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789";
+
+    private static readonly List<string> ProhibitedJobs = new()
+    {
+        "StationAi",
+        "Borg",
+    };
+
     private static readonly TimeSpan ToggleCooldown = TimeSpan.FromSeconds(0.5);
 
     public override void Initialize()
@@ -63,7 +71,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
 
     public void SpawnPassportForPlayer(EntityUid mob, HumanoidCharacterProfile profile, string? jobId)
     {
-        if (jobId is "StationAi" or "Borg")
+        if (ProhibitedJobs.Any(job => jobId == job))
             return;
 
         if (jobId == null || !_prototypeManager.TryIndex(jobId, out JobPrototype? _)

--- a/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared._WL.Records;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;
-using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Item;
@@ -32,7 +31,6 @@ public sealed partial class SharedPassportSystem : EntitySystem
     private const string NoConfederationId = "NoConfederation";
     private const string PIDChars = "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789";
     private static readonly TimeSpan ToggleCooldown = TimeSpan.FromSeconds(0.5);
-    private ISawmill _sawmill = default!;
 
     public override void Initialize()
     {
@@ -41,7 +39,6 @@ public sealed partial class SharedPassportSystem : EntitySystem
         SubscribeLocalEvent<PassportComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
         SubscribeLocalEvent<PassportComponent, ExaminedEvent>(OnExamined);
-        _sawmill = LogManager.GetSawmill("passport");
     }
 
     private void OnExamined(EntityUid uid, PassportComponent component, ExaminedEvent args)
@@ -66,24 +63,22 @@ public sealed partial class SharedPassportSystem : EntitySystem
 
     public void SpawnPassportForPlayer(EntityUid mob, HumanoidCharacterProfile profile, string? jobId)
     {
-        _sawmill.Debug($"Attempting passport spawn for {profile.Name}, job: {jobId}, confederation: {profile.Confederation}");
+        if (jobId is "StationAi" or "Borg")
+            return;
 
-        if (jobId == null || !_prototypeManager.TryIndex(jobId, out JobPrototype? jobPrototype)
+        if (jobId == null || !_prototypeManager.TryIndex(jobId, out JobPrototype? _)
                           || Deleted(mob)
                           || !Exists(mob))
-        {
-            _sawmill.Warning($"No valid jobId for {profile.Name}");
             return;
-        }
 
         var confederationId = string.IsNullOrEmpty(profile.Confederation)
             ? NoConfederationId
             : profile.Confederation;
 
         if (!_prototypeManager.TryIndex(confederationId, out ConfederationRecordsPrototype? confProto) ||
-            !_prototypeManager.TryIndex(confProto.PassportPrototype, out EntityPrototype? entityPrototype))
+            !_prototypeManager.TryIndex(confProto.PassportPrototype, out var entityPrototype))
         {
-            if (!_prototypeManager.TryIndex<ConfederationRecordsPrototype>(NoConfederationId, out confProto) ||
+            if (!_prototypeManager.TryIndex(NoConfederationId, out confProto) ||
                 !_prototypeManager.TryIndex(confProto.PassportPrototype, out entityPrototype))
                 return;
         }
@@ -113,7 +108,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
     {
         passport.Comp.OwnerProfile = profile;
 
-        var speciesProto = _prototypeManager.Index<SpeciesPrototype>(profile.Species);
+        var speciesProto = _prototypeManager.Index(profile.Species);
         var genderString = profile.Gender.ToString();
         passport.Comp.DisplayName = profile.Name;
         passport.Comp.DisplaySpecies = Loc.GetString(speciesProto.Name);

--- a/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_WL/Passports/Systems/SharedPassportSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class SharedPassportSystem : EntitySystem
 
     private void SpawnPassportForPlayer(EntityUid mob, HumanoidCharacterProfile profile, string? jobId)
     {
-        if (ProhibitedJobs.Any(job => jobId == job))
+        if (jobId != null && ProhibitedJobs.Contains<string>(jobId))
             return;
 
         if (jobId == null || !_prototypeManager.TryIndex(jobId, out JobPrototype? _)

--- a/Resources/Locale/ru-RU/_WL/passports/information.ftl
+++ b/Resources/Locale/ru-RU/_WL/passports/information.ftl
@@ -2,7 +2,7 @@ passport-registered-to = Имя: { $name }
 passport-species = Вид: { $species }
 passport-gender = Пол: { $gender }
 passport-height = Рост: { $height } см
-passport-year-of-birth = Год рождения: { $year }
+passport-date-of-birth = День рождения: { $date }
 passport-pid = Номер: { $pid }
 
 passport-identity-gender-feminine = Женский
@@ -15,6 +15,6 @@ chameleon-passport-menu-title = Настройка паспорта
 chameleon-passport-current-name = Имя:
 chameleon-passport-current-species = Вид:
 chameleon-passport-current-gender = Пол:
-chameleon-passport-current-year-of-birth = Год рождения:
+chameleon-passport-current-date-of-birth = День рождения:
 chameleon-passport-current-height = Рост:
 chameleon-passport-current-PID = Номер:

--- a/Resources/Locale/ru-RU/_WL/passports/information.ftl
+++ b/Resources/Locale/ru-RU/_WL/passports/information.ftl
@@ -2,7 +2,7 @@ passport-registered-to = Имя: { $name }
 passport-species = Вид: { $species }
 passport-gender = Пол: { $gender }
 passport-height = Рост: { $height } см
-passport-date-of-birth = День рождения: { $date }
+passport-date-of-birth = Дата рождения: { $date }
 passport-pid = Номер: { $pid }
 
 passport-identity-gender-feminine = Женский
@@ -15,6 +15,6 @@ chameleon-passport-menu-title = Настройка паспорта
 chameleon-passport-current-name = Имя:
 chameleon-passport-current-species = Вид:
 chameleon-passport-current-gender = Пол:
-chameleon-passport-current-date-of-birth = День рождения:
+chameleon-passport-current-date-of-birth = Дата рождения:
 chameleon-passport-current-height = Рост:
 chameleon-passport-current-PID = Номер:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Cleanup кода пасспорта, фикс бага со спавном паспорта у ИИ и боргов. 
Теперь в паспорте не использует год, а дату рождения. В случае если дата рождения не заполнена в меню, то он отображается в формате "xx.xx.нынешний год + 849"

## Почему / Баланс
чистота всему голова
ии и боргу паспорт не нужен
чтобы мозги не ебать с проверкой даты рождения

## Технические детали
чистка. изменение фтльки и кода

## Медиа
Заполненная дата рождения:
<img width="366" height="266" alt="image" src="https://github.com/user-attachments/assets/27630847-01e0-4816-84ed-ffe24cec232c" />

Незаполненная дата рождения: 
<img width="386" height="299" alt="image" src="https://github.com/user-attachments/assets/7f9115ca-4d9d-480f-9fdc-909a176455a5" />

Отображение в паспорте синдиката:
<img width="436" height="715" alt="image" src="https://github.com/user-attachments/assets/e1254fbd-778d-4668-b4b5-f6f9109a0de8" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-tweaks: В паспорте теперь показывается дата рождения из записей персонажа, а не год рождения
- wl-fix: Паспорт больше не спавнится у ИИ и боргов


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passports and chameleon passport UI now use and display a full date of birth (editable) instead of only year of birth.

* **Localization**
  * Russian passport text updated to reflect date-of-birth labels/placeholders.

* **Refactor**
  * Internal passport systems simplified (no user-facing behavior changes).

* **Chores**
  * Removed extraneous debug logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->