### PR TITLE
Долгая зомбификация

### DIFF
--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -24,8 +24,8 @@
     sound: "/Audio/Ambience/Antag/zombie_start.ogg"
   components:
   - type: PendingZombie #less time to prepare than normal
-    minInitialInfectedGrace: 300
-    maxInitialInfectedGrace: 450
+    minInitialInfectedGrace: 1200 # WL-Changes: 300 -> 1200
+    maxInitialInfectedGrace: 1800 # WL-Changes: 450 -> 1800
   - type: ZombifyOnDeath
   - type: IncurableZombie
   - type: InitialInfected


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
изменено время начала получения урона от зомбификации. вместо минимальных 5 минут и максимальных 7 с половиной - будет 20 минут минимально и 30 минут максимально

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
идея + рп по венам

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
поменять цифры в протке антага

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
<img width="860" height="460" alt="image" src="https://github.com/user-attachments/assets/fd171aec-3ca3-426a-945d-4e35d096fe47" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl: oldschool_otaku
- wl-tweak: Время для конвертации в зомби увеличено с 5-7,5 минут до 20-30 минут

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Balance Changes
* Extended the initial grace period for infected zombies during game start (increased from 5-7.5 minutes to 20-30 minutes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->