### PR TITLE
освещение для сварки

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Effects/welding_sparks.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Effects/welding_sparks.yml
@@ -17,7 +17,10 @@
   - type: AnimationPlayer
   - type: PointLight
     color: orange
-    radius: 1.5
+    # WL-Changes-Start
+    radius: 2.5
+    energy: 1.5
+    # WL-Changes-End
   - type: Tag
     tags:
     - HideContextMenu
@@ -32,5 +35,9 @@
     - state: smoke
     - state: exp_welding_sparks
       shader: unshaded
+  # WL-Changes-Start
   - type: PointLight
+    radius: 4.0
+    energy: 2.0
     color: MediumAquamarine
+  # WL-Changes-End


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Теперь те самые эффекты от сварки имеют более яркое освещение

## Почему / Баланс
это черт подери хайпово

## Технические детали
pointlight

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: Эффекты для сварки теперь ярче


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Visual Improvements**
  * Enhanced welding spark visual effects with adjusted light brightness and radius for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->