### PR TITLE
КПБ больше не слепнут

### DIFF
--- a/Resources/Prototypes/Corvax/Body/Species/ipc.yml
+++ b/Resources/Prototypes/Corvax/Body/Species/ipc.yml
@@ -216,6 +216,7 @@
     doAfterDelay: 20
     selfRepairPenalty: 2
   - type: DamagedSiliconAccent
+  - type: EyeProtection # WL-Changes
   - type: Reflect
     reflectProb: 0.05
   - type: SleepEmitSound

--- a/Resources/Prototypes/_WL/Body/Species/android.yml
+++ b/Resources/Prototypes/_WL/Body/Species/android.yml
@@ -174,6 +174,7 @@
   - type: Blindable
   - type: EyeProtection
   - type: FlashImmunity
+    showInExamine: false
   - type: Icon
     sprite: _WL/Mobs/Species/Android/parts.rsi
     state: full


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Тайтл. Плюс у андроидов больше не пишется крутая фраза "Обеспечивает защиту от [color=lightblue]ярких вспышек[/color]."

## Почему / Баланс
лорно и геймплейно круто

## Технические детали
EyeProtection и добавить фиговинку андроидам

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: КПБ больше не слепнут от сварки
- wl-fix: У андроидов убрана фраза "Обеспечивает защиту от ярких вспышек" при осмотре


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IPC species now equipped with eye protection against certain hazards.

* **Changes**
  * Updated flash immunity display settings for Android species to adjust information visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->