### PR TITLE
Перезарядка на ходу

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BallisticAmmoProviderComponent.cs
@@ -63,4 +63,10 @@ public sealed partial class BallisticAmmoProviderComponent : Component
     /// </summary>
     [DataField]
     public bool AutoCycle = true;
+
+    /// <summary>
+    /// Whitelist - Reloading on move
+    /// </summary>
+    [DataField]
+    public bool ReloadOnMove = false;
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedGunSystem
         // Continuous loading
         _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.FillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid)
         {
-            BreakOnMove = true,
+            BreakOnMove = false, //WL-Changes: Break on move is false
             BreakOnDamage = false,
             NeedHand = true,
         });

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -78,13 +78,27 @@ public abstract partial class SharedGunSystem
 
         args.Handled = true;
 
-        // Continuous loading
-        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.FillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid)
+        // WL-Changes-Start
+        if (component.ReloadOnMove)
         {
-            BreakOnMove = false, //WL-Changes: Break on move is false
-            BreakOnDamage = false,
-            NeedHand = true,
-        });
+            _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.FillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid)
+            {
+                BreakOnMove = false,
+                BreakOnDamage = false,
+                NeedHand = true,
+            });
+        }
+        else
+        {
+            // Continuous loading
+            _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.FillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid)
+            {
+                BreakOnMove = true,
+                BreakOnDamage = false,
+                NeedHand = true,
+            });
+        }
+        // WL-Changes-End
     }
 
     private void OnBallisticAmmoFillDoAfter(EntityUid uid, BallisticAmmoProviderComponent component, AmmoFillDoAfterEvent args)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -31,6 +31,7 @@
       sprite: Objects/Weapons/Guns/Ammunition/Boxes/shotgun.rsi
     - type: BallisticAmmoProvider
       mayTransfer: true
+      reloadOnMove: true # WL-Changes
       whitelist:
         tags:
         - ShellShotgun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
@@ -9,6 +9,7 @@
     - MagazineShotgun
   - type: BallisticAmmoProvider
     mayTransfer: true
+    reloadOnMove: true # WL-Changes
     whitelist:
       tags:
         - ShellShotgun


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
дробовики можно перезаряжать на ходу

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
https://discord.com/channels/1066727245806325872/1504956997869506620

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
изменить breakonmove с true на false

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
не надо

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-add: Дробовики и магазины можно перезаряжать на ходу


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable “reload on move” option for ballistic ammo providers.
  * Enabled reload-on-move for shotgun shell ammo boxes and the .50 shell shotgun magazine.
* **Bug Fixes**
  * Ballistic ammo transfer now follows the configured reload-on-move behavior, avoiding interruptions during player movement when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->