### PR TITLE
Микрофиксики

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_glass.yml
@@ -119,8 +119,8 @@
         - id: DrinkWhiteRussianGlass
         - id: DrinkWineGlass
         - id: XenoBasherGlass
-        - id: DrinkShakeBlue
-        - id: DrinkShakeWhite
+        #- id: DrinkShakeBlue # WL-Changes
+        #- id: DrinkShakeWhite # WL-Changes
         - id: DrinkTheMartinez
         - id: DrinkMoonshineGlass
       - !type:GroupSelector #rare
@@ -135,8 +135,8 @@
         - id: DrinkNeurotoxinGlass
         - id: DrinkNuclearColaGlass
         - id: DrinkSilencerGlass
-        - id: DrinkShakeMeat
-        - id: DrinkShakeRobo
+        # - id: DrinkShakeMeat # WL-Changes
+        # - id: DrinkShakeRobo # WL-Changes
         - id: DrinkHoochGlass
         - id: DrinkBeepskySmashGlass
         - id: DrinkBacchusBlessing

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -48,7 +48,7 @@
   # Well its fixed now, but I want to share my pain.
   - type: Solution
     solution:
-      maxVol: 1 # Cheap
+      maxVol: 5 # Cheap # WL-Changes: 1->5
   - type: SolutionTransfer
     maxTransferAmount: 1
   - type: Sprite
@@ -94,7 +94,7 @@
     solution:
       reagents:
       - ReagentId: Astrotame
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Sprite
     layers:
       - state: packet-trans-2
@@ -120,7 +120,7 @@
     solution:
       reagents:
       - ReagentId: BbqSauce
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-bbq
   - type: Appearance
@@ -138,7 +138,7 @@
     solution:
       reagents:
       - ReagentId: Cornoil
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-cornoil
   - type: Appearance
@@ -156,7 +156,7 @@
     solution:
       reagents:
       - ReagentId: Coldsauce
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-frostoil
   - type: Appearance
@@ -174,7 +174,7 @@
     solution:
       reagents:
       - ReagentId: HorseradishSauce
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-greygoo
   - type: Appearance
@@ -192,7 +192,7 @@
     solution:
       reagents:
       - ReagentId: Hotsauce
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-hotsauce
   - type: Appearance
@@ -210,7 +210,7 @@
     solution:
       reagents:
       - ReagentId: Ketchup
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Sprite
   - type: Icon
     state: packet-ketchup
@@ -229,7 +229,7 @@
     solution:
       reagents:
       - ReagentId: Mustard
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-mustard
   - type: Appearance
@@ -247,7 +247,7 @@
     solution:
       reagents:
       - ReagentId: Blackpepper
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-pepper
   - type: Appearance
@@ -265,7 +265,7 @@
     solution:
       reagents:
       - ReagentId: TableSalt
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Sprite
     layers:
       - state: packet-solid-2
@@ -292,7 +292,7 @@
     solution:
       reagents:
       - ReagentId: Soysauce
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-soysauce
   - type: Appearance
@@ -310,7 +310,7 @@
     solution:
       reagents:
       - ReagentId: Sugar
-        Quantity: 1
+        Quantity: 5 # WL-Changes: 1->5
   - type: Icon
     state: packet-sugar
   - type: Appearance


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Из спавнера рандомных напитков вырезаны коктейли(белый, мясной, синий, робо).
Пакетики соусов снова имеют свои законные 5 единиц соуса

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Коктейли сломаны нахуй. И зачем они в спавнере - никому включая визден неизвестно
За пакетики обидно. И поваров тоже

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Мейнтейнера во дворца, мейнтейнера во дворца. Закоменть то, измени циферку там.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
нет

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-remove: Вырезан мясной, белый, синий и робо коктейль из спавнера.
- wl-tweak: В пакетиках соусов снова 5 единиц соуса, заместо 1 единицы


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted condiment packets so they hold and dispense a more appropriate amount.
  * Updated several condiment packets to provide a fuller serving when used.

* **Content Changes**
  * Reduced the set of random drinks that can appear from the glass drink spawner, making its output more limited and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->