### PR TITLE
Откат плейтеста

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/coats.yml
@@ -15,10 +15,6 @@
           Slash: 0.7
           Piercing: 0.4
           Heat: 0.7
-  # WL-Stun-Resist-Playtest-Start
-    - type: StaminaResistance
-      damageCoefficient: 0.70
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: ClothingOuterCoatDetectiveLoadout
@@ -55,10 +51,6 @@
           Slash: 0.8
           Piercing: 0.4
           Heat: 0.8
-  # WL-Stun-Resist-Playtest-Start
-    - type: StaminaResistance
-      damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -110,10 +102,6 @@
         Slash: 0.5
         Piercing: 0.6
         Heat: 0.5
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.55
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -29,10 +29,6 @@
         Radiation: 0.1
   - type: ExplosionResistance
     damageCoefficient: 0.7
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0
-  # WL-Stun-Resist-Playtest-End
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURNLeader
 

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -212,10 +212,6 @@
   - type: Tag
     tags:
     - WhitelistChameleon
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.95
-  # WL-Stun-Resist-Playtest-End
 
 #Goliath Hardsuit
 - type: entity
@@ -292,10 +288,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.90
-  # WL-Stun-Resist-Playtest-End
 
 #Security Hardsuit
 - type: entity
@@ -394,10 +386,6 @@
   - type: Tag
     tags:
     - WhitelistChameleon
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
   - type: PointLight # Corvax-Resprite
     color: "#AF89D5FF"
 
@@ -543,10 +531,6 @@
   - type: PressureProtection
     highPressureMultiplier: 0.525
     lowPressureMultiplier: 1000
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.10
-  # WL-Stun-Resist-Playtest-End
   - type: PointLight
     radius: 7
     energy: 3
@@ -575,10 +559,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -606,10 +586,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -639,10 +615,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -670,10 +642,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -701,10 +669,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -974,10 +938,6 @@
         Heat: 0.9
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.10
-  # WL-Stun-Resist-Playtest-End
 
 #Deathsquad Hardsuit
 - type: entity
@@ -1022,10 +982,6 @@
     toggleAction: ToggleThermalVision
     isEquipment: true
   # WL-Thermal-Vision-End
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.80
-  # WL-Stun-Resist-Playtest-End
 
 #MISC. HARDSUITS
 #Clown Hardsuit

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -34,10 +34,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.90
-  # WL-Stun-Resist-Playtest-End
 
 #Basic Helmet (Security Helmet)
 - type: entity
@@ -93,10 +89,6 @@
         Heat: 0.80
         Radiation: 0.80
         Caustic: 0.95
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
   - type: ExplosionResistance
     damageCoefficient: 0.75
   - type: HideLayerClothing
@@ -137,10 +129,6 @@
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.95
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.80
-  # WL-Stun-Resist-Playtest-End
   - type: HideLayerClothing
     layers:
       Hair: HEAD
@@ -396,10 +384,6 @@
   - type: HideLayerClothing
     layers:
       Hair: HEAD
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 #ERT Security Helmet
 - type: entity
@@ -415,10 +399,6 @@
   - type: HideLayerClothing
     layers:
       Hair: HEAD
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 #ERT Medic Helmet
 - type: entity
@@ -434,10 +414,6 @@
   - type: HideLayerClothing
     layers:
       Hair: HEAD
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 #ERT Engineer Helmet
 - type: entity
@@ -453,10 +429,6 @@
   - type: HideLayerClothing
     layers:
       Hair: HEAD
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 #ERT Janitor Helmet
 - type: entity
@@ -472,10 +444,6 @@
   - type: HideLayerClothing
     layers:
       Hair: HEAD
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: [ BaseSyndicateContraband, ClothingHeadHelmetBase ]
@@ -494,10 +462,6 @@
         Slash: 0.85
         Piercing: 0.85
         Heat: 0.85
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.80
-  # WL-Stun-Resist-Playtest-End
   - type: HideLayerClothing
     layers:
       Hair: HEAD

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -53,10 +53,6 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.95
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: [ClothingMaskGas, BaseSyndicateContraband]
@@ -105,10 +101,6 @@
     sprite: Clothing/Mask/gascaptain.rsi
   - type: BreathMask
   - type: IngestionBlocker
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.90
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: [ ClothingMaskGasAtmos, BaseCentcommContraband ]
@@ -122,10 +114,6 @@
     sprite: Clothing/Mask/gascentcom.rsi
   - type: BreathMask
   - type: IngestionBlocker
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: [ClothingMaskGas, BaseCargoContraband]
@@ -496,10 +484,6 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.85
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: ClothingMaskGasERT

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -21,10 +21,6 @@
         Slash: 0.70
         Piercing: 0.70 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.80
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.70
-  # WL-Stun-Resist-Playtest-End
   - type: ExplosionResistance
     damageCoefficient: 0.90
 
@@ -87,10 +83,6 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.4 # this technically means it protects against fires pretty well? -heat is just for lasers and stuff, not atmos temperature
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.40
-  # WL-Stun-Resist-Playtest-End
   - type: Reflect
     reflectProb: 1
     reflects:
@@ -108,10 +100,6 @@
     sprite: Clothing/OuterClothing/Vests/detvest.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/detvest.rsi
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.55
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: [ ClothingOuterBaseMedium, AllowSuitStorageClothing ]
@@ -126,10 +114,6 @@
         Piercing: 0.6
         Heat: 0.5
         Caustic: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: GroupExamine
@@ -177,10 +161,6 @@
         Slash: 0.6
         Piercing: 0.3
         Heat: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.50
-  # WL-Stun-Resist-Playtest-End
   - type: StaticPrice
     price: 1500
 
@@ -207,10 +187,6 @@
         Heat: 0.3
         Radiation: 0.5
         Caustic: 0.5
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.50
-  # WL-Stun-Resist-Playtest-End
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: FireProtection
@@ -336,10 +312,6 @@
         Piercing: 0.7
         Heat: 0.9
         Caustic: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: GroupExamine
@@ -361,10 +333,6 @@
         Slash: 0.5
         Piercing: 0.5
         Heat: 0.5
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
   - type: GroupExamine
 
 - type: entity
@@ -386,10 +354,6 @@
         Heat: 0.5
         Radiation: 0
         Caustic: 0.75
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.20
-  # WL-Stun-Resist-Playtest-End
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
@@ -482,10 +446,6 @@
         Blunt: 0.6
         Slash: 0.8
         Piercing: 0.4
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.90
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -78,10 +78,6 @@
         Piercing: 0.6
         Heat: 0.7
         Caustic: 0.75 # not the full 90% from ss13 because of the head
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   abstract: true
@@ -96,10 +92,6 @@
         Piercing: 0.7
         Heat: 0.7
         Caustic: 0.9
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.65
-  # WL-Stun-Resist-Playtest-End
 
 - type: entity
   parent: [BaseSecurityCommandContraband, ClothingOuterArmorHoS]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -136,10 +136,6 @@
         Heat: 0.7
         Radiation: 0.3
         Caustic: 0.7
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.80
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -176,10 +172,6 @@
         Heat: 0.7 #Goliath hide gets grilled instead of you
         Radiation: 0.3
         Caustic: 0.8
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.70
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -251,10 +243,6 @@
         Piercing: 0.6
         Heat: 0.8
         Caustic: 0.7
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -286,10 +274,6 @@
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.7
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.40
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -321,10 +305,6 @@
         Piercing: 0.6
         Heat: 0.8
         Caustic: 0.7
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
@@ -357,10 +337,6 @@
         Heat: 0.5
         Radiation: 0.5
         Caustic: 0.6
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.60
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -511,10 +487,6 @@
         Heat: 0.8
         Radiation: 0.5
         Caustic: 0.6
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.50
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -548,10 +520,6 @@
         Heat: 0.9
         Radiation: 0.5
         Caustic: 0.8
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.75
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -579,7 +547,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere
-    damageCoefficient: 0.75   # WL-Stun-Resist-Playtest
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:
@@ -644,7 +612,7 @@
   - type: FireProtection
     reduction: 0.8
   - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere
-    damageCoefficient: 0.25 # WL-Stun-Resist-Playtest
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -684,7 +652,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere
-    damageCoefficient: 0.3   # WL-Stun-Resist-Playtest
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -732,10 +700,6 @@
         Heat: 0.2
         Radiation: 0.2
         Caustic: 0.2
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.50
-  # WL-Stun-Resist-Playtest-End
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -996,7 +960,7 @@
   - type: FireProtection
     reduction: 0.8
   - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere
-    damageCoefficient: 0.01 # Needs 21 hits with a disabler to stun :godo:  # WL-Stun-Resist-Playtest
+    damageCoefficient: 0.15 # Needs 21 hits with a disabler to stun :godo:
   - type: Armor
     modifiers:
       coefficients:
@@ -1043,10 +1007,6 @@
         Shock: 0.1
         Radiation: 0.1
         Caustic: 0.1
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.90
-  # WL-Stun-Resist-Playtest-End
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.25
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -136,10 +136,6 @@
         Heat: 0.90
         Radiation: 0.75
         Caustic: 0.5
-  # WL-Stun-Resist-Playtest-Start
-  - type: StaminaResistance
-    damageCoefficient: 0.80
-  # WL-Stun-Resist-Playtest-End
   - type: GroupExamine
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitVoidParamed


### PR DESCRIPTION
Откат стан резистов. Откатить после окончания плейтеста

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Changes**
  * Reduced or removed stamina/stun resistance from several clothing items, including coats, helmets, masks, armor vests, hardsuits, and softsuits.
  * Some special hardsuit variants now have updated resistance values instead of the previous playtest tuning.
  * Overall, these items should now offer less protection against stamina-based effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->