### PR TITLE
Not infinite speed boots

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -149,7 +149,7 @@
   - type: StaticPrice
     price: 500
   - type: PowerCellDraw
-    drawRate: 4
+    drawRate: 10 #wl - not-infinite-speed-boots
   - type: ToggleCellDraw
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -241,7 +241,7 @@
     maxCharge: 720
     startingCharge: 720
   - type: BatterySelfRecharger
-    autoRechargeRate: 12 # takes 1 minute to charge itself back to full
+    autoRechargeRate: 4 #wl - not-infinite-speed-boots
 
 - type: entity
   parent: PowerCellMicroreactor


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Сократил количество заряда микрореакторной батарии
В целом увеличил (ощутимо) потребляемую энергию скороходов:

> Нужно увеличить сжираемую скороходами энергию так, чтобы микрореакторная батарея не успевала восстановиться и уходила в минус от работы скороходов.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->

таск

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl: 21melkuu
- wl-tweak: Количество потребляемой энергии скороходов возрасло.
- wl-tweak: Количество генерируемой энергии микрореакторной батерии снижено.
<!--

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Some speed boots now consume more power when active, helping limit how long they can be used at full effect.
  * Microreactors now recharge at a slower rate, making power recovery more gradual.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->