### PR TITLE
Багфиксы

### DIFF
--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/clothing/head/hats.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/entities/clothing/head/hats.ftl
@@ -160,8 +160,10 @@ ent-ClothingHeadHatGreyFlatcap = серая плоская кепка
     .desc = В моде как у рабочего класса, так и у стариков навроде Дженкинса.
 ent-ClothingHeadHatBrownFlatcap = коричневая плоская кепка
     .desc = "\"Тупой клоун! Ты выставил меня в плохом свете!\""
+# Corvax-WL-Changes-Start
 ent-ClothingHeadHatCowboyBrown = коричневая ковбойская шляпа
-    .desc = "\"Эта шляпа слишком тесна для нас двоих.\""
+    .desc = Эта шляпа слишком тесна для нас двоих.
+# Corvax-WL-Changes-End
 ent-ClothingHeadHatCowboyBlack = чёрная ковбойская шляпа
     .desc = { ent-ClothingHeadHatCowboyBrown.desc }
 ent-ClothingHeadHatCowboyGrey = серая ковбойская шляпа

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -238,7 +238,7 @@
         probability: 0.12
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Rat, Vox, Cischi ] # Cischi
+          type: [ Rat, Vox, Cischi, Biorobotic ] # Cischi and Androids
           inverted: true
         - !type:ReagentCondition
           reagent: Ammonia

--- a/Resources/Prototypes/_WL/Body/Species/golem.yml
+++ b/Resources/Prototypes/_WL/Body/Species/golem.yml
@@ -9,6 +9,12 @@
      enum.HumanoidVisualLayers.HeadTop:
        limit: 1
        required: false
+    enum.HumanoidVisualLayers.Hair:
+      limit: 1
+      required: false
+    enum.HumanoidVisualLayers.FacialHair:
+      limit: 1
+      required: false
      enum.HumanoidVisualLayers.HeadSide:
        limit: 1
        required: false

--- a/Resources/Prototypes/_WL/Body/Species/golem.yml
+++ b/Resources/Prototypes/_WL/Body/Species/golem.yml
@@ -9,10 +9,10 @@
      enum.HumanoidVisualLayers.HeadTop:
        limit: 1
        required: false
-    enum.HumanoidVisualLayers.Hair:
+     enum.HumanoidVisualLayers.Hair:
       limit: 1
       required: false
-    enum.HumanoidVisualLayers.FacialHair:
+     enum.HumanoidVisualLayers.FacialHair:
       limit: 1
       required: false
      enum.HumanoidVisualLayers.HeadSide:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Описание ковбойской шляпы теперь нормальное
У големов теперь только одна пара волос(игрокам понравилось их иметь в целом)
Андроиды больше не блюют если дышат аммиаком

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
баг репорты

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
ямль

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: Големам ограничили волосы до одной пары
- wl-fix: Андроиды больше не блюют если вдыхают аммиак
- wl-fix: Описание ковбойской шляпы больше не "
