### PR TITLE
Больше зарядов

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -83,7 +83,7 @@
     color: Red
     selectableColor: true
   - type: LimitedCharges
-    maxCharges: 30
+    maxCharges: 1000 # WL-Changes: 30 -> 1000
 
 - type: entity
   parent: CrayonRainbow

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -74,6 +74,7 @@
   description: A cartridge of highly compressed paint, commonly used in spray painters.
   components:
   - type: SprayPainterAmmo
+    charges: 150 # WL-Changes
   - type: Sprite
     sprite: Objects/Tools/spray_painter.rsi
     state: ammo


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Сжатая краска теперь имеет 150 зарядов, как у краскопульта
Радужному мелку дано 1000 зарядов

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
У нас рисуют значительно чаще. Это круто, значит поощеряется.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
ЦИФОРКИ ПОМЕНЯТЬ

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
нет

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: Колличество зарядов у сжатой краски увеличено до 150.
- wl-tweak: Колличество зарядов у радужного мелка увеличено до 1000.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Rainbow crayons now support up to 1,000 uses, providing significantly more charges before replacement.
  - Spray painter ammunition now includes 150 charges, offering a clearly defined and more reliable supply for painting tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->