### PR TITLE
Баффы фонариков

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -104,7 +104,7 @@
         Heat: 0.90
         Radiation: 0.75
   - type: PointLight
-    radius: 5
+    radius: 5 # WL-Changes
     energy: 2
     color: "#00ffff"
   - type: Tag

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -59,6 +59,7 @@
       #  shader: unshaded
   - type: PointLight
     color: "#adffe6"
+    radius: 5 # WL-Changes
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -125,6 +126,7 @@
       #  shader: unshaded
   - type: PointLight
     color: "#ffdbad"
+    radius: 5 # WL-Changes
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
@@ -455,6 +457,7 @@
       #  shader: unshaded
   - type: PointLight # Corvax-Resprite
     color: "#e6aa5c"
+    radius: 5 # WL-Changes
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Фонарики у скафандров атмосов, инженеров, парамедиков и СИ имеют радиус 5

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Они больше работают в космосе чем остальные должности. Им нужен фонарь лучше

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
ЦИФОРКУ ПОМЕНЯТ

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
роскомхуесос не дает картинку загрузить через гитхаб
<img width="1096" height="1129" alt="image" src="https://media.discordapp.net/attachments/1507482507308699779/1525101259017818313/image.png?ex=6a5228bb&is=6a50d73b&hm=aef9f90f6ee638ecfcad81e8294d2ca4eafe56e189faea14c975f2a87f056c86&=&format=webp&quality=lossless&width=979&height=1008" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

**Список изменений**
:cl:
- wl-tweak: Увеличена дальность у скафандровкафандров атмосов, инженеров, парамедиков и СИ до 5 тайлов