### PR TITLE
теперь можно писать о-о-о-о

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -16,7 +16,7 @@ public sealed partial class ChatSanitizationManager : IChatSanitizationManager
     [
         // Corvax-Localization-Start
         Entry("хд", "chatsan-laughs"),
-        Entry("о-о", "chatsan-wide-eyed"), // cyrillic о
+        // Entry("о-о", "chatsan-wide-eyed"), // cyrillic о // corvax-wl remove
         Entry("о.о", "chatsan-wide-eyed"), // cyrillic о
         Entry("0_о", "chatsan-wide-eyed"), // cyrillic о
         Entry("о/", "chatsan-waves"), // cyrillic о


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
о-о с кириллическими буквами не автозаменяется на *Выглядит шокированным*

## Почему / Баланс
растянутые гласные буквы в письменном виде следует отделять дефисом (правильно не дооолго а до-о-олго) но дурацкая автозамена не даёт это сделать

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [LICENSE](../LICENSE.md) и [CLA](../CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- wl-remove: Убрано веселье в виде автозамены о-о на "Выглядит шокированным"!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Cyrillic shorthand “о-о” for the wide-eyed chat emote.
  * This shorthand will no longer automatically convert to or trigger the associated emote.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->