### PR TITLE
Upstream fixes 1

### DIFF
--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -66,7 +66,7 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
     protected void ActivateCartridge(EntityUid cartridgeUid)
     {
         var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.Activate);
-        SendPredictedMessage(message);
+        SendMessage(message); // WL-Changes-start
     }
 
     protected void DeactivateActiveCartridge()
@@ -132,7 +132,7 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
     private void SendCartridgeUiReadyEvent(EntityUid cartridgeUid)
     {
         var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.UIReady);
-        SendMessage(message);
+        SendPredictedMessage(message); // WL-Changes-start
     }
 
     private UIFragment? RetrieveCartridgeUI(EntityUid? cartridgeUid)

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -73,13 +73,13 @@ public sealed partial class RoleSystem : SharedRoleSystem
         return genericProfile as HumanoidCharacterProfile;
     }
 
+    // WL-Changes-start
     public string? GetSubnameByMind(MindComponent mind, string jobId)
     {
-        if (mind != null)
-            if (mind.OwnedEntity.HasValue)
-                return GetSubnameByEntity(mind.OwnedEntity.Value, jobId);
+        if (mind == null || !mind.OwnedEntity.HasValue)
+            return null;
 
-        return null;
+        return GetSubnameByEntity(mind.OwnedEntity.Value, jobId);
     }
 
     public string? GetSubnameByEntity(EntityUid entity, string jobId)
@@ -88,14 +88,7 @@ public sealed partial class RoleSystem : SharedRoleSystem
         if (profile == null)
             return null;
 
-        if (!profile.JobSubnames.TryGetValue(jobId, out var subname))
-            return null;
-
-        if (ProtoMan.TryIndex<JobPrototype>(jobId, out var proto))
-            if (!proto.GetSubnames(profile.Gender).Contains(subname))
-                return proto.LocalizedName;
-
-        return subname;
+        return GetSubname(profile, jobId);
     }
 
     public string? GetSubnameBySesssion(ICommonSession? session, string jobId)
@@ -107,15 +100,9 @@ public sealed partial class RoleSystem : SharedRoleSystem
         if (profile == null)
             return null;
 
-        if (!profile.JobSubnames.TryGetValue(jobId, out var subname))
-            return null;
-
-        if (ProtoMan.TryIndex<JobPrototype>(jobId, out var proto))
-            if (!proto.GetSubnames(profile.Gender).Contains(subname))
-                return proto.LocalizedName;
-
-        return subname;
+        return GetSubname(profile, jobId);
     }
+    // WL-Changes-end
 
     public void RoleUpdateMessage(MindComponent mind)
     {

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -58,6 +58,19 @@ public abstract partial class SharedRoleSystem : EntitySystem
             Log.Error($"Unknown JobRequirementOverridePrototype: {value}");
     }
 
+    // WL-Changes-start
+    public string? GetSubname(HumanoidCharacterProfile profile, ProtoId<JobPrototype> jobId)
+    {
+        if (!profile.JobSubnames.TryGetValue(jobId, out var subname))
+            return null;
+
+        if (ProtoMan.TryIndex(jobId, out var proto) && !proto.GetSubnames(profile.Gender).Contains(subname))
+            return proto.LocalizedName;
+
+        return subname;
+    }
+    // WL-Changes-end
+
     /// <summary>
     ///     Adds multiple mind roles to a mind
     /// </summary>

--- a/Content.Shared/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Shared/StationRecords/Systems/StationRecordsSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared._WL.Languages;
+using Content.Shared._WL.Languages.Components;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Forensics.Components;
@@ -9,7 +11,9 @@ using Content.Shared.Roles;
 using Content.Shared.StationRecords.Components;
 using Content.Shared.StationRecords.Events;
 using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using System.Linq;
 
 namespace Content.Shared.StationRecords.Systems;
 
@@ -38,6 +42,10 @@ public sealed partial class StationRecordsSystem : EntitySystem
     [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private StationRecordKeyStorageSystem _keyStorage = default!;
     [Dependency] private SharedIdCardSystem _idCard = default!;
+
+    // WL-Changes-start
+    [Dependency] private SharedRoleSystem _role = default!;
+    // WL-Changes-end
 
     [Dependency] private EntityQuery<IdCardComponent> _idCardQuery = default!;
     [Dependency] private EntityQuery<PdaComponent> _pdaQuery = default!;
@@ -97,6 +105,10 @@ public sealed partial class StationRecordsSystem : EntitySystem
         _fingerprintQuery.TryComp(player, out var fingerprintComponent);
         _dnaQuery.TryComp(player, out var dnaComponent);
 
+        // WL-Changes-start
+        TryComp<LanguagesComponent>(player, out var languageComponent);
+        // WL-Changes-end
+
         CreateGeneralRecord(
             station,
             idUid.Value,
@@ -107,7 +119,8 @@ public sealed partial class StationRecordsSystem : EntitySystem
             jobId,
             fingerprintComponent?.Fingerprint,
             dnaComponent?.DNA,
-            profile);
+            profile,
+            /*WL-Changes-start*/languageComponent?.Speaking.ToList() ?? []/*WL-Changes-end*/);
     }
 
     /// <summary>
@@ -146,14 +159,15 @@ public sealed partial class StationRecordsSystem : EntitySystem
         string jobId,
         string? mobFingerprint,
         string? dna,
-        HumanoidCharacterProfile profile)
+        HumanoidCharacterProfile profile,
+        /*WL-Changes-start*/List<ProtoId<LanguagePrototype>> languages/*WL-Changes-end*/)
     {
         if (!ProtoMan.TryIndex<JobPrototype>(jobId, out var jobPrototype))
             throw new ArgumentException($"Invalid job prototype ID: {jobId}");
 
         // when adding a record that already exists use the old one
         // this happens when respawning as the same character
-        if (GetRecordByName(station.AsNullable(), name) is {} id)
+        if (GetRecordByName(station.AsNullable(), name) is { } id)
         {
             SetIdKey(idUid, new StationRecordKey(id, station));
             return;
@@ -163,14 +177,27 @@ public sealed partial class StationRecordsSystem : EntitySystem
         {
             Name = name,
             Age = age,
-            JobTitle = jobPrototype.LocalizedName,
+            // WL-Changes-start
+            JobTitle = _role.GetSubname(profile, jobId) ?? jobPrototype.LocalizedName,
+            // WL-Changes-end
             JobIcon = jobPrototype.Icon,
             JobPrototype = jobId,
             Species = species,
             Gender = gender,
             DisplayPriority = jobPrototype.RealDisplayWeight,
             Fingerprint = mobFingerprint,
-            DNA = dna
+            DNA = dna,
+            // WL-Changes-start
+            EmploymentRecord = profile.EmploymentRecord,
+            MedicalRecord = profile.MedicalRecord,
+            SecurityRecord = profile.SecurityRecord,
+            Confederation = profile.Confederation,
+            Country = profile.Country,
+            DateOfBirth = profile.DateOfBirth,
+            Height = profile.Height,
+            Fullname = profile.FullName,
+            Languages = languages
+            // WL-Changes-end
         };
 
         var key = AddRecordEntry(station.AsNullable(), record);


### PR DESCRIPTION
## Описание PR
Починил отображение записей персонажа в консольках (https://discord.com/channels/1066727245806325872/1529947410112188537)
Починил отображение манифеста в кпк и новостей (https://discord.com/channels/1066727245806325872/1529945191358795937)

## Почему / Баланс
https://discord.com/channels/1066727245806325872/1529947410112188537
https://discord.com/channels/1066727245806325872/1529945191358795937
https://discord.com/channels/1066727245806325872/1238531945483210772/1529943204030451742

## Технические детали
Вынес дублирующуюся логику в subname методаъ серверного RoleSystem в Shared версию, в остальном всё.

## Медиа
<img width="651" height="525" alt="Скриншот 24-07-2026 163439" src="https://github.com/user-attachments/assets/700ce8b2-8f04-4c06-9105-a54ac33e6bcd" />

<img width="744" height="539" alt="Скриншот 24-07-2026 163413" src="https://github.com/user-attachments/assets/50e39906-e523-401d-b1c3-1fc02f2f126f" />

## Требования
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я протестировал этот пул-реквест и НЕ написал инструкции по его проверке.
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [x] Я согласен с условиями [Лицензии](https://github.com/corvax-team/ss14-wl/blob/master/LICENSE.md) и [CLA](https://github.com/corvax-team/ss14-wl/blob/master/CLA.md).


**Список изменений**

:cl:
- wl-fix: Исправлен баг с бесконечной загрузкой манифеста.
- wl-fix: Исправлен баг с отсутствием новостей в кпк.
- wl-fix: Исправлен баг с некорректным отображением записей персонажа в консолях записей.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cartridge interface activation and readiness handling for more reliable UI updates.
  - Corrected job subname resolution across character, entity, and session views, including gender-specific naming.

- **Improvements**
  - Station records now display more complete character information, including employment, medical, security, identity, birth date, height, and languages.
  - Job titles now consistently use customized subnames when available, with appropriate fallback titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->