### PR TITLE
Улучшение Барков (Ритм, Наложение).

### DIFF
--- a/Content.Client/_WL/Barks/SpeechBarksSystem.cs
+++ b/Content.Client/_WL/Barks/SpeechBarksSystem.cs
@@ -23,6 +23,9 @@ public sealed partial class SpeechBarksSystem : EntitySystem
     private const float PitchVariation = 0.1f;
     private const float MinPlaybackPitch = 0.45f;
     private const float MaxPlaybackPitch = 1.85f;
+    // Let adjacent grains overlap slightly without allowing long samples to
+    // pile up into an unintelligible wall of sound.
+    private const float PlaybackFractionBeforeNextBark = 0.75f;
 
     [Dependency] private AudioSystem _audio = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
@@ -77,6 +80,7 @@ public sealed partial class SpeechBarksSystem : EntitySystem
     private void OnBarks(PlaySpeechBarksEvent ev)
     {
         if (_speechMode != SpeechMode.Barks ||
+            ev.Rhythm.Length == 0 ||
             !TryGetEntity(ev.Source, out var source) ||
             Transform(source.Value).MapID == MapId.Nullspace)
             return;
@@ -84,10 +88,8 @@ public sealed partial class SpeechBarksSystem : EntitySystem
         var pitch = SpeechBarksComponent.SanitizePitch(ev.Pitch);
         var (minDelay, maxDelay) =
             SpeechBarksComponent.SanitizeDelays(ev.MinDelay, ev.MaxDelay);
-        // Keep ADT's speech behaviour: every message and every already-started
-        // grain is allowed to finish independently. This is what makes very
-        // short voice collections sound like natural game dialogue instead of
-        // a stream repeatedly cut by a concurrency limiter.
+        // Already-started grains are allowed to finish, while complete phrases
+        // from the same speaker are played sequentially.
         QueueBark(
             source.Value,
             ev.Sound,
@@ -96,7 +98,7 @@ public sealed partial class SpeechBarksSystem : EntitySystem
             AdjustVolume(ev.Prosody, ev.IsWhisper),
             minDelay,
             maxDelay,
-            Math.Max(1, ev.Count),
+            ev.Rhythm,
             ev.Prosody,
             false);
     }
@@ -125,7 +127,7 @@ public sealed partial class SpeechBarksSystem : EntitySystem
             AdjustVolume(prosody, false),
             minDelay,
             maxDelay,
-            BarkProsody.GetBarkCount(message),
+            BarkProsody.GetBarkRhythm(message),
             prosody,
             true);
     }
@@ -138,11 +140,14 @@ public sealed partial class SpeechBarksSystem : EntitySystem
         float volume,
         float minDelay,
         float maxDelay,
-        int count,
+        BarkBoundary[] rhythm,
         BarkProsody prosody,
         bool isPreview)
     {
-        _active.Add(new ActiveBark(
+        if (rhythm.Length == 0)
+            return;
+
+        var queued = new ActiveBark(
             source,
             sound,
             pitch,
@@ -150,9 +155,26 @@ public sealed partial class SpeechBarksSystem : EntitySystem
             volume,
             minDelay,
             maxDelay,
-            count,
+            rhythm,
             prosody,
-            isPreview));
+            isPreview);
+
+        if (!isPreview && source is { } speaker)
+        {
+            foreach (var active in _active)
+            {
+                if (active.IsPreview || active.Source != speaker)
+                    continue;
+
+                // A person cannot naturally speak two phrases at once. Keep
+                // only their newest pending phrase to avoid a delayed backlog
+                // after chat spam.
+                active.Pending = queued;
+                return;
+            }
+        }
+
+        _active.Add(queued);
     }
 
     public void StopPreview()
@@ -180,18 +202,37 @@ public sealed partial class SpeechBarksSystem : EntitySystem
             if (bark.NextSound > _timing.CurTime)
                 continue;
 
-            if (bark.Played >= bark.Count || bark.Source is { } source && Deleted(source))
+            if (bark.Source is { } source && Deleted(source))
             {
                 _active.RemoveAt(i);
                 continue;
             }
 
-            var progress = bark.Count <= 1
+            if (bark.Played >= bark.Count)
+            {
+                if (bark.Pending is { } pending)
+                {
+                    pending.NextSound = _timing.CurTime;
+                    _active[i] = pending;
+                }
+                else
+                {
+                    _active.RemoveAt(i);
+                }
+
+                continue;
+            }
+
+            var progress = bark.Rhythm.Length <= 1
                 ? 1f
-                : bark.Played / (bark.Count - 1f);
+                : bark.Played / (bark.Rhythm.Length - 1f);
+            var boundary = bark.Rhythm[bark.Played];
             var variation = _random.NextFloat(1f - PitchVariation, 1f + PitchVariation);
             var pitch = Math.Clamp(
-                bark.Pitch * bark.Prosody.GetPitchMultiplier(progress) * variation,
+                bark.Pitch *
+                bark.Prosody.GetPitchMultiplier(progress) *
+                boundary.GetPitchMultiplier() *
+                variation,
                 MinPlaybackPitch,
                 MaxPlaybackPitch);
 
@@ -231,6 +272,10 @@ public sealed partial class SpeechBarksSystem : EntitySystem
             bark.Played++;
             var cadence = _random.NextFloat(bark.MinDelay, bark.MaxDelay);
             cadence *= bark.Prosody.DelayScale;
+            cadence = Math.Max(
+                cadence,
+                (float) playbackDuration.TotalSeconds * PlaybackFractionBeforeNextBark);
+            cadence += boundary.GetAdditionalDelay();
             bark.NextSound = _timing.CurTime + TimeSpan.FromSeconds(cadence);
         }
     }
@@ -255,7 +300,7 @@ public sealed partial class SpeechBarksSystem : EntitySystem
         float volume,
         float minDelay,
         float maxDelay,
-        int count,
+        BarkBoundary[] rhythm,
         BarkProsody prosody,
         bool isPreview = false)
     {
@@ -266,11 +311,14 @@ public sealed partial class SpeechBarksSystem : EntitySystem
         public float Volume = volume;
         public float MinDelay = minDelay;
         public float MaxDelay = maxDelay;
-        public int Count = count;
+        public BarkBoundary[] Rhythm = rhythm;
         public BarkProsody Prosody = prosody;
         public bool IsPreview = isPreview;
         public int Played;
         public TimeSpan NextSound;
+        public ActiveBark? Pending;
+
+        public int Count => Rhythm.Length;
     }
 
 }

--- a/Content.Server/_WL/Barks/SpeechBarksSystem.cs
+++ b/Content.Server/_WL/Barks/SpeechBarksSystem.cs
@@ -33,13 +33,17 @@ public sealed partial class SpeechBarksSystem : EntitySystem
         var (minDelay, maxDelay) =
             SpeechBarksComponent.SanitizeDelays(transform.MinDelay, transform.MaxDelay);
         var prosody = BarkProsody.FromMessage(args.Message);
+        var rhythm = BarkProsody.GetBarkRhythm(args.Message);
+        if (rhythm.Length == 0)
+            return;
+
         var ev = new PlaySpeechBarksEvent(
             GetNetEntity(ent),
             voice.Sound,
             pitch,
             minDelay,
             maxDelay,
-            BarkProsody.GetBarkCount(args.Message),
+            rhythm,
             prosody,
             args.ObfuscatedMessage != null);
 

--- a/Content.Shared/_WL/Barks/BarkBoundary.cs
+++ b/Content.Shared/_WL/Barks/BarkBoundary.cs
@@ -1,0 +1,48 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._WL.Barks;
+
+[Serializable, NetSerializable]
+public enum BarkBoundary : byte
+{
+    None,
+    Comma,
+    Clause,
+    Period,
+    Question,
+    Exclamation,
+    Ellipsis,
+}
+
+public static class BarkBoundaryExtensions
+{
+    public static float GetAdditionalDelay(this BarkBoundary boundary)
+    {
+        return boundary switch
+        {
+            BarkBoundary.Comma => 0.12f,
+            BarkBoundary.Clause => 0.2f,
+            BarkBoundary.Period => 0.28f,
+            BarkBoundary.Question => 0.28f,
+            BarkBoundary.Exclamation => 0.24f,
+            BarkBoundary.Ellipsis => 0.42f,
+            _ => 0f,
+        };
+    }
+
+    public static float GetPitchMultiplier(this BarkBoundary boundary)
+    {
+        var semitones = boundary switch
+        {
+            BarkBoundary.Comma => 0.5f,
+            BarkBoundary.Clause => -0.5f,
+            BarkBoundary.Period => -1f,
+            BarkBoundary.Question => 1.5f,
+            BarkBoundary.Exclamation => 1f,
+            BarkBoundary.Ellipsis => -1.5f,
+            _ => 0f,
+        };
+
+        return MathF.Pow(2f, semitones / 12f);
+    }
+}

--- a/Content.Shared/_WL/Barks/BarkEvents.cs
+++ b/Content.Shared/_WL/Barks/BarkEvents.cs
@@ -12,7 +12,7 @@ public sealed class PlaySpeechBarksEvent(
     float pitch,
     float minDelay,
     float maxDelay,
-    int count,
+    BarkBoundary[] rhythm,
     BarkProsody prosody,
     bool isWhisper) : EntityEventArgs
 {
@@ -21,7 +21,7 @@ public sealed class PlaySpeechBarksEvent(
     public float Pitch = pitch;
     public float MinDelay = minDelay;
     public float MaxDelay = maxDelay;
-    public int Count = count;
+    public BarkBoundary[] Rhythm = rhythm;
     public BarkProsody Prosody = prosody;
     public bool IsWhisper = isWhisper;
 }

--- a/Content.Shared/_WL/Barks/BarkProsody.cs
+++ b/Content.Shared/_WL/Barks/BarkProsody.cs
@@ -14,6 +14,9 @@ public readonly record struct BarkProsody(
     float DelayScale,
     float VolumeOffset)
 {
+    private const int MaxBarkCount = 24;
+    private const string CyrillicVowels = "аеёиоуыэюяіїє";
+
     public static readonly BarkProsody Neutral = new(0f, 0f, 1f, 0f);
 
     public float GetPitchMultiplier(float progress)
@@ -39,10 +42,130 @@ public readonly record struct BarkProsody(
 
     public static int GetBarkCount(string message)
     {
-        // Match ADT: one initial grain, then one more for every three
-        // characters. Exact multiples intentionally receive the trailing
-        // grain as well (3 -> 2, 6 -> 3).
-        return Math.Max(1, message.Length / 3 + 1);
+        return GetBarkRhythm(message).Length;
+    }
+
+    public static BarkBoundary[] GetBarkRhythm(string message)
+    {
+        var rhythm = new List<BarkBoundary>(Math.Min(message.Length, MaxBarkCount));
+        var wordStart = -1;
+
+        for (var i = 0; i <= message.Length; i++)
+        {
+            if (i < message.Length && char.IsLetterOrDigit(message[i]))
+            {
+                if (wordStart == -1)
+                    wordStart = i;
+
+                continue;
+            }
+
+            if (wordStart != -1)
+            {
+                var syllables = EstimateWordSyllables(message.AsSpan(wordStart, i - wordStart));
+                for (var syllable = 0; syllable < syllables && rhythm.Count < MaxBarkCount; syllable++)
+                    rhythm.Add(BarkBoundary.None);
+
+                wordStart = -1;
+            }
+
+            if (i < message.Length && rhythm.Count > 0)
+            {
+                var boundary = GetBoundary(message, i);
+                if (GetBoundaryPriority(boundary) > GetBoundaryPriority(rhythm[^1]))
+                    rhythm[^1] = boundary;
+            }
+        }
+
+        return rhythm.ToArray();
+    }
+
+    private static BarkBoundary GetBoundary(string message, int index)
+    {
+        return message[index] switch
+        {
+            ',' => BarkBoundary.Comma,
+            ';' or ':' => BarkBoundary.Clause,
+            '—' or '–' => BarkBoundary.Clause,
+            '-' when (index > 0 && char.IsWhiteSpace(message[index - 1])) ||
+                (index + 1 < message.Length && char.IsWhiteSpace(message[index + 1])) => BarkBoundary.Clause,
+            '?' => BarkBoundary.Question,
+            '!' => BarkBoundary.Exclamation,
+            '.' when (index > 0 && message[index - 1] == '.') ||
+                (index + 1 < message.Length && message[index + 1] == '.') => BarkBoundary.Ellipsis,
+            '.' => BarkBoundary.Period,
+            '\n' or '\r' => BarkBoundary.Period,
+            _ => BarkBoundary.None,
+        };
+    }
+
+    private static int GetBoundaryPriority(BarkBoundary boundary)
+    {
+        return boundary switch
+        {
+            BarkBoundary.None => 0,
+            BarkBoundary.Comma => 1,
+            BarkBoundary.Clause => 2,
+            BarkBoundary.Period => 3,
+            BarkBoundary.Question => 4,
+            BarkBoundary.Exclamation => 5,
+            BarkBoundary.Ellipsis => 6,
+            _ => 0,
+        };
+    }
+
+    private static int EstimateWordSyllables(ReadOnlySpan<char> word)
+    {
+        var syllables = 0;
+        var hasCyrillicVowel = false;
+        var insideLatinVowelGroup = false;
+
+        for (var i = 0; i < word.Length; i++)
+        {
+            var character = char.ToLowerInvariant(word[i]);
+            if (CyrillicVowels.Contains(character))
+            {
+                syllables++;
+                hasCyrillicVowel = true;
+                insideLatinVowelGroup = false;
+                continue;
+            }
+
+            if (IsLatinVowel(character, i))
+            {
+                if (!insideLatinVowelGroup)
+                    syllables++;
+
+                insideLatinVowelGroup = true;
+                continue;
+            }
+
+            insideLatinVowelGroup = false;
+        }
+
+        if (!hasCyrillicVowel && HasSilentLatinE(word) && syllables > 1)
+            syllables--;
+
+        // Numbers, abbreviations and words from unsupported alphabets still
+        // need one grain so that they do not disappear from the rhythm.
+        return Math.Max(1, syllables);
+    }
+
+    private static bool IsLatinVowel(char character, int index)
+    {
+        return character is 'a' or 'e' or 'i' or 'o' or 'u' ||
+            character == 'y' && index > 0;
+    }
+
+    private static bool HasSilentLatinE(ReadOnlySpan<char> word)
+    {
+        if (word.Length < 2 || char.ToLowerInvariant(word[^1]) != 'e')
+            return false;
+
+        // A final consonant + "le", as in "table", normally forms a syllable.
+        return word.Length < 3 ||
+            char.ToLowerInvariant(word[^2]) != 'l' ||
+            IsLatinVowel(char.ToLowerInvariant(word[^3]), word.Length - 3);
     }
 
     private static EmotionalEnding GetEmotionalEnding(string message)

--- a/Content.Tests/Shared/_WL/Barks/BarkProsodyTest.cs
+++ b/Content.Tests/Shared/_WL/Barks/BarkProsodyTest.cs
@@ -81,14 +81,81 @@ public sealed class BarkProsodyTest
         });
     }
 
-    [TestCase("", 1)]
-    [TestCase("а", 1)]
-    [TestCase("аб", 1)]
-    [TestCase("абв", 2)]
-    [TestCase("абвг", 2)]
-    [TestCase("абвгде", 3)]
-    public void BarkCountUsesOneGrainPerThreeCharacters(string message, int expected)
+    [TestCase("", 0)]
+    [TestCase("...", 0)]
+    [TestCase("?!, - —", 0)]
+    [TestCase("Ку.", 1)]
+    [TestCase("Привет.", 2)]
+    [TestCase("Здрав-ствуй-те.", 3)]
+    [TestCase("Здравствуйте.", 3)]
+    [TestCase("Привет, как дела?", 5)]
+    [TestCase("hello", 2)]
+    [TestCase("voice", 1)]
+    [TestCase("table", 2)]
+    [TestCase("123 РП", 2)]
+    public void BarkCountFollowsSpokenSyllables(string message, int expected)
     {
         Assert.That(BarkProsody.GetBarkCount(message), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BarkCountIsCappedForLongMessages()
+    {
+        Assert.That(
+            BarkProsody.GetBarkCount(new string('а', 100)),
+            Is.EqualTo(24));
+    }
+
+    [Test]
+    public void PunctuationCreatesRhythmWithoutExtraBarks()
+    {
+        var rhythm = BarkProsody.GetBarkRhythm("Привет, мир. Как дела?");
+
+        Assert.That(rhythm, Is.EqualTo(new[]
+        {
+            BarkBoundary.None,
+            BarkBoundary.Comma,
+            BarkBoundary.Period,
+            BarkBoundary.None,
+            BarkBoundary.None,
+            BarkBoundary.Question,
+        }));
+    }
+
+    [Test]
+    public void EllipsisCreatesTheLongestPause()
+    {
+        var rhythm = BarkProsody.GetBarkRhythm("Да... Нет!");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rhythm, Is.EqualTo(new[]
+            {
+                BarkBoundary.Ellipsis,
+                BarkBoundary.Exclamation,
+            }));
+            Assert.That(
+                rhythm[0].GetAdditionalDelay(),
+                Is.GreaterThan(rhythm[1].GetAdditionalDelay()));
+        });
+    }
+
+    [Test]
+    public void PunctuationChangesExistingBarksWithoutAddingNewOnes()
+    {
+        var plain = BarkProsody.GetBarkRhythm("Привет мир");
+        var punctuated = BarkProsody.GetBarkRhythm("Привет, мир. Да!");
+        var dashed = BarkProsody.GetBarkRhythm("Привет — мир");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plain, Has.Length.EqualTo(3));
+            Assert.That(punctuated, Has.Length.EqualTo(4));
+            Assert.That(punctuated[1], Is.EqualTo(BarkBoundary.Comma));
+            Assert.That(punctuated[2], Is.EqualTo(BarkBoundary.Period));
+            Assert.That(punctuated[3], Is.EqualTo(BarkBoundary.Exclamation));
+            Assert.That(dashed, Has.Length.EqualTo(3));
+            Assert.That(dashed[1], Is.EqualTo(BarkBoundary.Clause));
+        });
     }
 }


### PR DESCRIPTION
## Описание PR

Барки теперь лучше следуют ритму текста. Количество звуков примерно соответствует слогам, а знаки препинания меняют паузы и интонацию, не создавая отдельные звуки.

Также реплики одного персонажа больше не накладываются друг на друга целиком.

## Почему / Баланс

Короткие слова иногда получали слишком много звуков, а длинные фразы звучали монотонно. Новая логика делает барки спокойнее и ближе к обычной речи.

## Технические детали

- Подсчёт барков основан на слогах русских и английских слов
- Запятые, точки, вопросы, восклицания, многоточия и тире меняют паузу и высоту звука
- Знаки препинания сами не озвучиваются
- Учитывается реальная длина аудиофайла, соседние звуки перекрываются не больше чем примерно на четверть
- Для одного говорящего проигрывается одна реплика и хранится одна ожидающая
- Вместо текста клиент получает только компактный ритмический рисунок

## План тестирования

1. Выбрать барки в редакторе персонажа
2. Сравнить фразы Ку, Привет и Здравствуйте
3. Проверить фразу Привет, как дела? Всё хорошо...
4. Быстро отправить несколько сообщений одним персонажем
5. Проверить речь нескольких персонажей одновременно

Сервер и клиент собираются. Профильные тесты барков прошли 35 из 35.

## Медиа

https://github.com/user-attachments/assets/93b0f32d-57f8-447b-8afd-b58102f13e3c


## Требования

- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я протестировал этот пул-реквест и написал инструкции по его проверке.
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями

- [X] Я согласен с условиями [Лицензии](https://github.com/corvax-team/ss14-wl/blob/master/LICENSE.md) и [CLA](https://github.com/corvax-team/ss14-wl/blob/master/CLA.md).

## Критические изменения

PlaySpeechBarksEvent теперь передаёт ритмический рисунок вместо одного числа. Дополнительных действий не требуется.

**Список изменений**

:cl: wzzker21
- wl-tweak: Барки теперь учитывают слоги и пунктуацию и меньше накладываются друг на друга.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Speech barks now follow spoken syllables and punctuation for more natural pacing.
  * Pauses and pitch adjust based on punctuation, including longer pauses for ellipses.
  * New speech phrases from the same speaker replace pending phrases while current sounds finish playing.
  * Playback cadence is prevented from becoming faster than the audio duration.

* **Bug Fixes**
  * Long messages are capped to prevent excessive bark playback.
  * Messages without playable rhythm no longer trigger unnecessary playback events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->