### PR TITLE
сообщения остаются до конца озвучки

### DIFF
--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -186,6 +186,19 @@ namespace Content.Client.Chat.UI
             }
         }
 
+        // WL-Changes-Start: Keep voiced messages visible until their audio finishes
+        /// <summary>
+        /// Keeps the bubble fully visible until <paramref name="playbackEndTime"/>,
+        /// then gives it the usual fade-out time.
+        /// </summary>
+        public void KeepAliveUntil(TimeSpan playbackEndTime)
+        {
+            var requestedDeathTime = playbackEndTime + FadeTime;
+            if (requestedDeathTime > _deathTime)
+                _deathTime = requestedDeathTime;
+        }
+        // WL-Changes-End
+
         protected FormattedMessage FormatSpeech(string message, Color? fontColor = null)
         {
             var msg = new FormattedMessage();

--- a/Content.Client/Corvax/TTS/TTSSystem.cs
+++ b/Content.Client/Corvax/TTS/TTSSystem.cs
@@ -3,8 +3,10 @@ using Content.Shared._WL.CCVars; // WL-Changes
 using Content.Shared.Corvax.CCCVars;
 using Content.Shared._WL.Barks; // WL-Changes
 using Content.Shared.Corvax.TTS;
+using Content.Client.UserInterface.Systems.Chat; // WL-Changes
 using Robust.Client.Audio;
 using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface; // WL-Changes
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
@@ -22,6 +24,7 @@ public sealed partial class TTSSystem : EntitySystem
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IResourceManager _res = default!;
     [Dependency] private AudioSystem _audio = default!;
+    [Dependency] private IUserInterfaceManager _ui = default!; // WL-Changes
 
     private ISawmill _sawmill = default!;
     private static MemoryContentRoot _contentRoot = new();
@@ -104,7 +107,15 @@ public sealed partial class TTSSystem : EntitySystem
                 return;
             }
 
-            _audio.PlayEntity(audioResource.AudioStream, sourceUid, soundSpecifier, audioParams);
+            var stream = _audio.PlayEntity(audioResource.AudioStream, sourceUid, soundSpecifier, audioParams);
+
+            // WL-Changes-Start: Keep the overhead message visible for the full TTS playback
+            if (stream != null)
+            {
+                _ui.GetUIController<ChatUIController>()
+                    .KeepSpeechBubbleVisible(sourceUid, audioResource.AudioStream.Length);
+            }
+            // WL-Changes-End
         }
         else
         {

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -136,6 +136,14 @@ public sealed partial class ChatUIController : UIController
     private readonly Dictionary<EntityUid, SpeechBubbleQueueData> _queuedSpeechBubbles
         = new();
 
+    // WL-Changes-Start: Keep voiced messages visible until their audio finishes
+    /// <summary>
+    /// Playback can begin just before its chat message reaches the bubble queue.
+    /// Remember the deadline so the newly created bubble still receives it.
+    /// </summary>
+    private readonly Dictionary<EntityUid, TimeSpan> _speechPlaybackEndTimes = new();
+    // WL-Changes-End
+
     private readonly HashSet<ChatBox> _chats = new();
     public IReadOnlySet<ChatBox> Chats => _chats;
 
@@ -469,6 +477,14 @@ public sealed partial class ChatUIController : UIController
         existing.Add(bubble);
         _speechBubbleRoot.AddChild(bubble);
 
+        // WL-Changes-Start: Keep voiced messages visible until their audio finishes
+        if (_speechPlaybackEndTimes.TryGetValue(entity, out var playbackEndTime) &&
+            playbackEndTime > _timing.RealTime)
+        {
+            bubble.KeepAliveUntil(playbackEndTime);
+        }
+        // WL-Changes-End
+
         if (existing.Count > SpeechBubbleCap)
         {
             // Get the next speech bubble to fade
@@ -591,8 +607,37 @@ public sealed partial class ChatUIController : UIController
 
     public override void FrameUpdate(FrameEventArgs delta)
     {
+        // WL-Changes-Start: Keep voiced messages visible until their audio finishes
+        foreach (var (entity, playbackEndTime) in _speechPlaybackEndTimes.ShallowClone())
+        {
+            if (playbackEndTime <= _timing.RealTime)
+                _speechPlaybackEndTimes.Remove(entity);
+        }
+        // WL-Changes-End
+
         UpdateQueuedSpeechBubbles(delta);
     }
+
+    // WL-Changes-Start: Keep voiced messages visible until their audio finishes
+    /// <summary>
+    /// Keeps the newest bubble for an entity visible for the remaining speech playback.
+    /// </summary>
+    public void KeepSpeechBubbleVisible(EntityUid entity, TimeSpan playbackDuration)
+    {
+        if (playbackDuration <= TimeSpan.Zero)
+            return;
+
+        var playbackEndTime = _timing.RealTime + playbackDuration;
+        if (!_speechPlaybackEndTimes.TryGetValue(entity, out var currentEndTime) ||
+            playbackEndTime > currentEndTime)
+        {
+            _speechPlaybackEndTimes[entity] = playbackEndTime;
+        }
+
+        if (_activeSpeechBubbles.TryGetValue(entity, out var bubbles) && bubbles.Count > 0)
+            bubbles[^1].KeepAliveUntil(playbackEndTime);
+    }
+    // WL-Changes-End
 
     private void UpdateQueuedSpeechBubbles(FrameEventArgs delta)
     {

--- a/Content.Client/_WL/Barks/SpeechBarksSystem.cs
+++ b/Content.Client/_WL/Barks/SpeechBarksSystem.cs
@@ -1,8 +1,10 @@
 using Content.Shared.Chat;
 using Content.Shared._WL.Barks;
 using Content.Shared._WL.CCVars;
+using Content.Client.UserInterface.Systems.Chat;
 using Robust.Client.Audio;
 using Robust.Client.Player;
+using Robust.Client.UserInterface;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
@@ -30,6 +32,7 @@ public sealed partial class SpeechBarksSystem : EntitySystem
     [Dependency] private IPlayerManager _player = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IPrototypeManager _prototypes = default!;
+    [Dependency] private IUserInterfaceManager _ui = default!;
 
     private readonly List<ActiveBark> _active = new();
     private readonly HashSet<EntityUid> _previewStreams = new();
@@ -232,6 +235,20 @@ public sealed partial class SpeechBarksSystem : EntitySystem
             var cadence = _random.NextFloat(bark.MinDelay, bark.MaxDelay);
             cadence *= bark.Prosody.DelayScale;
             bark.NextSound = _timing.CurTime + TimeSpan.FromSeconds(cadence);
+
+            if (!bark.IsPreview && bark.Source is { } speechSource && streamEntity != null)
+            {
+                // Keep the bubble visible through both the current grain and the pause
+                // before the next one. The final grain only uses its playback duration.
+                var timeUntilNextGrain = bark.Played < bark.Count
+                    ? TimeSpan.FromSeconds(cadence)
+                    : TimeSpan.Zero;
+                var remainingPlayback = playbackDuration > timeUntilNextGrain
+                    ? playbackDuration
+                    : timeUntilNextGrain;
+                _ui.GetUIController<ChatUIController>()
+                    .KeepSpeechBubbleVisible(speechSource, remainingPlayback);
+            }
         }
     }
 


### PR DESCRIPTION
## Описание PR

Сообщения над персонажем теперь остаются на экране, пока проигрываются TTS или барки.

## Почему / Баланс

Длинное сообщение могло исчезнуть раньше, чем заканчивалась его озвучка. Теперь текст и голос не расходятся по времени.

## Технические детали

Для TTS используется реальная длительность полученного аудиофайла.

Для барков учитывается длительность каждого звука и пауза до следующего. Стандартные 4 секунды показа сообщения не сокращаются.

## План тестирования

1. Выбрать режим барков.
2. Отправить длинное сообщение.
3. Убедиться, что сообщение остаётся над персонажем до окончания барков.
4. Повторить проверку с TTS на сервере с настроенным TTS API.
5. Выключить озвучивание и убедиться, что сообщения работают как раньше.

## Медиа


https://github.com/user-attachments/assets/c76dccd4-4f72-48c6-9499-b84c6f6b9308



Добавлю короткое видео.

## Требования

- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я протестировал этот пул-реквест и написал инструкции по его проверке.
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями

- [X] Я согласен с условиями [Лицензии](https://github.com/corvax-team/ss14-wl/blob/master/LICENSE.md) и [CLA](https://github.com/corvax-team/ss14-wl/blob/master/CLA.md).

## Критические изменения

Нет.

**Список изменений**

:cl: wzzker21
- wl-tweak: Сообщения над персонажами теперь остаются на экране до окончания озвучивания.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Speech bubbles now remain visible until associated voice playback finishes.
  - Chat bubbles stay visible across speech segments and are extended when longer playback is detected.
  - Prevents speech bubbles from fading out before audio completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->