### PR TITLE
bark playback limit

### DIFF
--- a/Content.Client/_WL/Barks/SpeechBarksSystem.cs
+++ b/Content.Client/_WL/Barks/SpeechBarksSystem.cs
@@ -25,6 +25,7 @@ public sealed partial class SpeechBarksSystem : EntitySystem
     private const float PitchVariation = 0.1f;
     private const float MinPlaybackPitch = 0.45f;
     private const float MaxPlaybackPitch = 1.85f;
+    private const float MaxBarkPlaybackSeconds = 0.6f;
     // Let adjacent grains overlap slightly without allowing long samples to
     // pile up into an unintelligible wall of sound.
     private const float PlaybackFractionBeforeNextBark = 0.75f;
@@ -246,7 +247,7 @@ public sealed partial class SpeechBarksSystem : EntitySystem
 
             var sound = _audio.ResolveSound(bark.Sound);
             var playbackDuration = TimeSpan.FromSeconds(
-                _audio.GetAudioLength(sound).TotalSeconds / pitch);
+                Math.Min(_audio.GetAudioLength(sound).TotalSeconds / pitch, MaxBarkPlaybackSeconds));
             EntityUid? streamEntity = null;
 
             if (bark.Source == null || bark.Source == _player.LocalEntity)


### PR DESCRIPTION
## Описание PR
ограничил длительность воспроизведения длинных bark-звуков, чтобы они не звучали слишком медленно.

## Почему / Баланс
длинные барки, вроде банжо и гитары, проигрывались целиком и из-за этого ощущались затянутыми. короткие барки это не затрагивает, а длинные теперь звучат живее и ближе к ожидаемому темпу.

## Технические детали
в `Content.Client/_WL/Barks/SpeechBarksSystem.cs` добавлен верхний лимит длительности одного bark-воспроизведения и `playbackduration` теперь берётся как минимум между реальной длиной звука и этим лимитом.

## План тестирования
зайдите и потыкайте

## Медиа
не требуется.

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я протестировал этот пул-реквест и написал инструкции по его проверке.
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [Х] Я согласен с условиями [Лицензии](https://github.com/corvax-team/ss14-wl/blob/master/LICENSE.md) и [CLA](https://github.com/corvax-team/ss14-wl/blob/master/CLA.md).

## Критические изменения
нет.

**Список изменений**
:cl:
- wl-fix: укорочено воспроизведение длинных bark-звуков, чтобы они не звучали слишком медленно.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited individual speech bark playback to 0.6 seconds, preventing unexpectedly long audio clips after pitch adjustments.
  * Improved timing consistency for bark playback and scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->