### PR TITLE
возраст мозга вместо возраста тела у андроидов

### DIFF
--- a/Resources/Locale/ru-RU/_WL/records/records.ftl
+++ b/Resources/Locale/ru-RU/_WL/records/records.ftl
@@ -17,7 +17,7 @@ records-employment-placeholder = Нажмите "Шаблон" для загру
 
 records-full-name-edit = ФИО:
 records-date-of-birth-edit = ДАТА РОЖДЕНИЯ:
-records-date-of-manufacture-edit = ДАТА ИЗГОТОВЛЕНИЯ:
+records-date-of-manufacture-edit = ДАТА ПОЯВЛЕНИЯ МОЗГА:
 records-date-day = ДД
 records-date-month = ММ
 records-date-year = ГГГГ

--- a/Resources/Prototypes/_WL/Skills/racialskillbonus.yml
+++ b/Resources/Prototypes/_WL/Skills/racialskillbonus.yml
@@ -77,12 +77,10 @@
   id: AndroidSkillBonuses
   species: Android
   ageBonuses:
-    22: 5
-    24: 3
-    30: 3
-    40: 3
-    55: 2
-    70: 2
+    1: 5
+    18: 3
+    30: 5
+    60: 3
 
 - type: racialSkillBonus
   id: MurineSkillBonuses

--- a/Resources/Prototypes/_WL/Species/android.yml
+++ b/Resources/Prototypes/_WL/Species/android.yml
@@ -7,6 +7,7 @@
   skinColoration: Hues
   minHeight: 120
   maxHeight: 250
+  minAge: 0
   maxAge: 200
   voices:
   - MaleAndroid


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
см ченжлог 

## План тестирования
зайти на сервер
поставить возраст 0 лет андроиду
проверить что навыки на месте

## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я протестировал этот пул-реквест и написал инструкции по его проверке.
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [Лицензии](https://github.com/corvax-team/ss14-wl/blob/master/LICENSE.md) и [CLA](https://github.com/corvax-team/ss14-wl/blob/master/CLA.md).

**Список изменений**

:cl:
- wl-tweak: Андроидам теперь может быть 0 лет. Теперь подразумевается, что в графе "возраст" будет писаться возраст мозга
- wl-tweak: "Дата изготовления" в рекордсах заменено на "Дата появления мозга"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Russian label for an Android character’s date of manufacture.
- **Gameplay**
  - Updated Android skill bonuses across different age ranges.
  - Android characters can now have an age from 0 to 200 years.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->