### PR TITLE
Dynamic description for items

### DIFF
--- a/Content.Client/_WL/DynamicText/DynamicTextSystem.cs
+++ b/Content.Client/_WL/DynamicText/DynamicTextSystem.cs
@@ -17,6 +17,7 @@ public sealed partial class DynamicTextSystem : EntitySystem
     [Dependency] private MindSystem _mindSystem = default!;
 
     private EntityUid? _editingEntity;
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Client/_WL/DynamicText/DynamicTextSystem.cs
+++ b/Content.Client/_WL/DynamicText/DynamicTextSystem.cs
@@ -1,5 +1,7 @@
 using Content.Client._WL.DynamicText.UI;
+using Content.Client.Mind;
 using Content.Shared._WL.DynamicText;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Verbs;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
@@ -12,6 +14,9 @@ public sealed partial class DynamicTextSystem : EntitySystem
     [Dependency] private IEntityManager _ent = default!;
     [Dependency] private IPlayerManager _player = default!;
     [Dependency] private IUserInterfaceManager _userInterfaceManager = default!;
+    [Dependency] private MindSystem _mindSystem = default!;
+
+    private EntityUid? _editingEntity;
     public override void Initialize()
     {
         base.Initialize();
@@ -23,8 +28,15 @@ public sealed partial class DynamicTextSystem : EntitySystem
     private void OnGetVerbs(GetVerbsEvent<Verb> args)
     {
         if (_player.LocalEntity is not { } player ||
-            args.User != player ||
-            args.Target != player)
+            args.User != player)
+        {
+            return;
+        }
+
+        var isSelf = args.Target == player;
+
+        if (!isSelf &&
+            (_mindSystem.TryGetMind(args.Target, out _, out _) || HasComp<MobStateComponent>(args.Target)))
         {
             return;
         }
@@ -35,21 +47,24 @@ public sealed partial class DynamicTextSystem : EntitySystem
             Icon = new SpriteSpecifier.Texture(
                 new ResPath("/Textures/_WL/Interface/VerbIcons/pen.svg.192dpi.png")),
             ClientExclusive = true,
-            Act = () => _userInterfaceManager
-                .GetUIController<DynamicTextUIController>()
-                .OpenWindow(),
+
+            Act = () =>
+            {
+                SetEditingEntity(args.Target);
+
+                _userInterfaceManager
+                    .GetUIController<DynamicTextUIController>()
+                    .OpenWindow();
+            },
         });
     }
 
     public void SaveDynamicText(string text)
     {
-        if (!_player.LocalEntity.HasValue)
+        if (_editingEntity is not { } editingEntity)
             return;
 
-        if (!_ent.TryGetNetEntity(_player.LocalEntity.Value, out var netEntity))
-            return;
-
-        if (text is null)
+        if (!_ent.TryGetNetEntity(editingEntity, out var netEntity))
             return;
 
         RaiseNetworkEvent(new SetDynamicTextEvent(netEntity.Value, text));
@@ -57,10 +72,10 @@ public sealed partial class DynamicTextSystem : EntitySystem
 
     public void RequestDynamicText()
     {
-        if (!_player.LocalEntity.HasValue)
+        if (_editingEntity is not { } editingEntity)
             return;
 
-        if (!_ent.TryGetNetEntity(_player.LocalEntity.Value, out var netEntity))
+        if (!_ent.TryGetNetEntity(editingEntity, out var netEntity))
             return;
 
         RaiseNetworkEvent(new RequestDynamicTextEvent(netEntity.Value));
@@ -69,5 +84,15 @@ public sealed partial class DynamicTextSystem : EntitySystem
     private void OnDynamicTextReceived(RequestedDynamicTextEvent ev, EntitySessionEventArgs args)
     {
         _userInterfaceManager.GetUIController<DynamicTextUIController>().SetDynamicText(ev.DynamicText);
+    }
+
+    public void SetEditingEntity(EntityUid uid)
+    {
+        _editingEntity = uid;
+    }
+
+    public void ClearEditingEntity()
+    {
+        _editingEntity = null;
     }
 }

--- a/Content.Client/_WL/DynamicText/UI/DynamicTextUIController.cs
+++ b/Content.Client/_WL/DynamicText/UI/DynamicTextUIController.cs
@@ -14,6 +14,9 @@ public sealed partial class DynamicTextUIController : UIController
         {
             _dynamicTextWindow = UIManager.CreateWindow<DynamicTextWindow>();
             _dynamicTextWindow.OnDynamicTextSaveButtonPressed += OnSave;
+
+            if (_dynamicTextWindow != null)
+                _dynamicTextWindow.OnClose += () => _entManager.System<DynamicTextSystem>().ClearEditingEntity();
         }
 
         _entManager.System<DynamicTextSystem>().RequestDynamicText();

--- a/Content.Client/_WL/DynamicText/UI/DynamicTextWindow.xaml.cs
+++ b/Content.Client/_WL/DynamicText/UI/DynamicTextWindow.xaml.cs
@@ -36,6 +36,11 @@ public sealed partial class DynamicTextWindow : FancyWindow
     public void SetDynamicText(string text)
     {
         CDynamicTextInput.TextRope = new Rope.Leaf(text);
+
+        CDynamicTextInput.CursorPosition = new TextEdit.CursorPos(
+            text.Length,
+            TextEdit.LineBreakBias.Top);
+
         UpdateCharacterCounter(text.Trim().Length);
     }
 

--- a/Content.Server/_WL/CharacterInformation/CharacterInformationComponent.cs
+++ b/Content.Server/_WL/CharacterInformation/CharacterInformationComponent.cs
@@ -13,8 +13,4 @@ public sealed partial class CharacterInformationComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public string OocText = string.Empty;
-
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField]
-    public string DynamicText = string.Empty;
 }

--- a/Content.Server/_WL/DynamicText/DynamicTextSystem.cs
+++ b/Content.Server/_WL/DynamicText/DynamicTextSystem.cs
@@ -45,8 +45,8 @@ public sealed partial class DynamicTextSystem : EntitySystem
             return;
 
         if (args.SenderSession.AttachedEntity != ent
-            && _mindSystem.TryGetMind(ent.Value, out var _, out var _)
-            && HasComp<MobStateComponent>(ent))
+            && (_mindSystem.TryGetMind(ent.Value, out var _, out var _)
+            || HasComp<MobStateComponent>(ent)))
             return;
 
         var comp = EnsureComp<DynamicTextComponent>(ent.Value);
@@ -73,8 +73,8 @@ public sealed partial class DynamicTextSystem : EntitySystem
             return;
 
         if (args.SenderSession.AttachedEntity != ent
-            && _mindSystem.TryGetMind(ent.Value, out var _, out var _)
-            && HasComp<MobStateComponent>(ent))
+            && (_mindSystem.TryGetMind(ent.Value, out var _, out var _)
+            || HasComp<MobStateComponent>(ent)))
             return;
 
         var comp = EnsureComp<DynamicTextComponent>(ent.Value);

--- a/Content.Server/_WL/DynamicText/DynamicTextSystem.cs
+++ b/Content.Server/_WL/DynamicText/DynamicTextSystem.cs
@@ -1,10 +1,12 @@
 using Content.Server._WL.CharacterInformation;
+using Content.Server.Mind;
 using Content.Server.Popups;
 using Content.Shared._WL.CCVars;
 using Content.Shared._WL.DynamicText;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;
+using Content.Shared.Mobs.Components;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
@@ -17,6 +19,7 @@ public sealed partial class DynamicTextSystem : EntitySystem
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private MindSystem _mindSystem = default!;
 
     private int _maxLength;
 
@@ -26,7 +29,7 @@ public sealed partial class DynamicTextSystem : EntitySystem
 
         SubscribeNetworkEvent<SetDynamicTextEvent>(SetDynamicText);
         SubscribeNetworkEvent<RequestDynamicTextEvent>(RequestDynamicText);
-        SubscribeLocalEvent<CharacterInformationComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<DynamicTextComponent, ExaminedEvent>(OnExamine);
         _cfg.OnValueChanged(WLCVars.MaxDynamicTextLength, (val) => _maxLength = val, true);
     }
 
@@ -41,20 +44,22 @@ public sealed partial class DynamicTextSystem : EntitySystem
         if (!_ent.TryGetEntity(ev.Entity, out var ent))
             return;
 
-        if (!TryComp<CharacterInformationComponent>(ent, out var comp))
+        if (args.SenderSession.AttachedEntity != ent
+            && _mindSystem.TryGetMind(ent.Value, out var _, out var _)
+            && HasComp<MobStateComponent>(ent))
             return;
 
-        if (args.SenderSession.AttachedEntity != ent)
-            return;
+        var comp = EnsureComp<DynamicTextComponent>(ent.Value);
 
         var newText = ev.DynamicText.Length > _maxLength
             ? FormattedMessage.RemoveMarkupOrThrow(ev.DynamicText)[.._maxLength]
             : FormattedMessage.RemoveMarkupOrThrow(ev.DynamicText);
 
-        if (newText == comp.DynamicText)
+        if (newText == comp.Text)
             return;
 
-        comp.DynamicText = newText;
+        comp.Text = newText;
+        Dirty(ent.Value, comp);
 
         var name = Name(ent.Value);
         _popup.PopupEntity(Loc.GetString("dynamic-text-changed-popup", ("name", name)), ent.Value);
@@ -67,21 +72,22 @@ public sealed partial class DynamicTextSystem : EntitySystem
         if (!_ent.TryGetEntity(ev.Entity, out var ent))
             return;
 
-        if (args.SenderSession.AttachedEntity != ent)
+        if (args.SenderSession.AttachedEntity != ent
+            && _mindSystem.TryGetMind(ent.Value, out var _, out var _)
+            && HasComp<MobStateComponent>(ent))
             return;
 
-        if (!TryComp<CharacterInformationComponent>(ent, out var comp))
-            return;
+        var comp = EnsureComp<DynamicTextComponent>(ent.Value);
 
-        RaiseNetworkEvent(new RequestedDynamicTextEvent(comp.DynamicText ?? string.Empty), Filter.SinglePlayer(args.SenderSession));
+        RaiseNetworkEvent(new RequestedDynamicTextEvent(comp.Text ?? string.Empty), Filter.SinglePlayer(args.SenderSession));
     }
 
-    private void OnExamine(EntityUid uid, CharacterInformationComponent comp, ExaminedEvent args)
+    private void OnExamine(EntityUid uid, DynamicTextComponent comp, ExaminedEvent args)
     {
-        using (args.PushGroup(nameof(CharacterInformationComponent)))
+        using (args.PushGroup(nameof(DynamicTextComponent)))
         {
-            if (!string.IsNullOrEmpty(comp.DynamicText))
-                args.PushMarkup("[color=#B5C7EB][bold]" + comp.DynamicText + "[/bold][/color]");
+            if (!string.IsNullOrEmpty(comp.Text))
+                args.PushMarkup("[color=#B5C7EB][bold]" + comp.Text + "[/bold][/color]");
         }
     }
 }

--- a/Content.Shared/_WL/DynamicText/DynamicTextComponent.cs
+++ b/Content.Shared/_WL/DynamicText/DynamicTextComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._WL.DynamicText;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class DynamicTextComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public string Text = string.Empty;
+}


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Игрок теперь может добавлять динамическое описание для предметов. Другим игрокам и животным не может.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
[Task](https://ru.yougile.com/board/iav4fm1aqwae/messenger#PRT-641)

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Динамическое описание переехало в DynamicTextComponent.

## План тестирования
<!--
Опишите, как вы тестировали пул-реквест и как его можно протестировать самостоятельно.
-->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
<img width="871" height="457" alt="image" src="https://github.com/user-attachments/assets/727fdcbe-34ac-4db4-b114-250f14ba3a02" />


## Требования
<!-- Подтвердите следующее, поставив X в скобках без пробелов [X]: -->
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я протестировал этот пул-реквест и написал инструкции по его проверке.
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

## Согласие с условиями
- [X] Я согласен с условиями [Лицензии](https://github.com/corvax-team/ss14-wl/blob/master/LICENSE.md) и [CLA](https://github.com/corvax-team/ss14-wl/blob/master/CLA.md).

<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- wl-tweak: Динамическое описание теперь можно применять к предметам.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic text can now be edited on eligible entities, rather than only on the local player.
  - Text is stored and displayed consistently for supported entities.
  - Editing automatically clears when the window is closed.
- **Bug Fixes**
  - Prevented dynamic text editing for living entities with minds or active mob states.
  - The text cursor now moves to the end of newly loaded text, making continued editing smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->